### PR TITLE
Fix mobile overflow from price section container

### DIFF
--- a/index.html
+++ b/index.html
@@ -1462,7 +1462,7 @@ const HERO_FRAMES = [
       --shadow-md:0 8px 24px rgba(0,0,0,.35);
       --shadow-lg:0 24px 48px rgba(0,0,0,.45);
       --speed:200ms;
-      --container:1200px; /* по брифу */
+      --container:min(1200px, 92vw); /* по брифу, без переполнения на мобилках */
     }
 
     /* Фон секции: динамичный тёмный градиент + вуаль */


### PR DESCRIPTION
## Summary
- prevent the price section CSS custom property from forcing a 1200px layout on narrow screens
- ensure the shared container width variable caps at the viewport width so mobile pages do not overflow

## Testing
- Viewed index.html with a mobile viewport in Playwright

------
https://chatgpt.com/codex/tasks/task_e_6907a58df888832faca6f9fdb18a52aa