### PR TITLE
Fix CTA button text wrapping on service cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -1001,16 +1001,17 @@ const HERO_FRAMES = [
       padding: 0 16px 16px 16px;
     }
     .btn {
-      display: flex; align-items: center; justify-content: center;
-      min-height: 40px; padding: 10px 14px; border-radius: 10px;
+      display: flex; align-items: center; justify-content: center; flex-wrap: wrap; row-gap: 2px;
+      min-height: 40px; padding: 12px 14px; border-radius: 10px;
       border: 1px solid rgba(255,255,255,.16);
       background: rgba(255,255,255,.06); color: #fff; text-decoration: none;
-      font-weight: 600; font-size: 14px; letter-spacing: .02em;
+      font-weight: 600; font-size: 14px; letter-spacing: .02em; line-height: 1.25; text-align: center;
       transition: background-color .2s ease, border-color .2s ease, transform .2s ease, box-shadow .2s ease;
       box-shadow: 0 6px 20px rgba(0,0,0,.24);
       width: 100%;
-      text-align: center;
       white-space: normal;
+      word-break: break-word;
+      overflow-wrap: anywhere;
     }
     .btn.primary {
       background: var(--accent); color: #101215; border-color: rgba(0,0,0,.08);


### PR DESCRIPTION
## Summary
- allow service card buttons to wrap text instead of overflowing
- adjust padding and line-height so multi-line CTAs stay readable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907c1b32608832f864a8ecb515b03a6