### PR TITLE
Adjust mobile metric layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,9 @@
   .tm-hero__container{grid-template-columns:1fr;padding:28px 0}
   .tm-hero__cta{gap:10px}
   .tm-metrics{grid-template-columns:1fr}
+  .tm-metric{grid-template-columns:1fr;justify-items:center;text-align:center}
+  .tm-metric__icon{margin:0 auto 8px}
+  .tm-metric__value{margin-bottom:4px}
   .tm-hero__logo{max-width:300px;margin-top:10px}
 }
 /* TM-MARK: CSS END */


### PR DESCRIPTION
## Summary
- center the hero metric content on narrow screens
- ensure metric values stack vertically beneath their icons on mobile

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907c7cbccdc832f99c168965aea64cb