### PR TITLE
Improve mobile cases slider layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -2225,26 +2225,31 @@ Assumptions (разумные допущения):
 </section>
 
 <style>
+@import url('https://unpkg.com/swiper@10/swiper-bundle.min.css');
+
 .cases-section {background: rgba(18,20,24,0.9) url('photo 8.png') center/cover no-repeat;color:#fff;padding:80px 0;scroll-margin-top:88px;}
 .container {max-width:1280px;margin:0 auto;padding:0 16px;}
 .section-title {text-align:center;font-size:2rem;margin-bottom:40px;}
 
-.swiper {overflow:hidden;}
+.cases-slider {position:relative;overflow:hidden;padding-bottom:48px;}
 .swiper-wrapper {display:flex;}
-.swiper-slide {flex-shrink:0;width:auto;}
+.swiper-slide {flex-shrink:0;height:auto;}
 
-.case-card {background:rgba(20,22,26,0.85);border-radius:12px;overflow:hidden;transition:transform .25s ease,box-shadow .25s ease;cursor:pointer;min-width:280px;}
+.case-card {background:rgba(20,22,26,0.85);border-radius:12px;overflow:hidden;transition:transform .25s ease,box-shadow .25s ease;cursor:pointer;min-width:0;display:flex;flex-direction:column;height:100%;}
 .case-card:hover {transform:scale(1.02);box-shadow:0 8px 20px rgba(0,0,0,.4);}
 .case-image {position:relative;height:180px;overflow:hidden;}
 .case-image img {width:100%;height:100%;object-fit:cover;}
 .gradient-mask {position:absolute;inset:0;background:linear-gradient(to top,rgba(0,0,0,0.7),transparent);}
-.badges {position:absolute;top:10px;left:10px;display:flex;gap:6px;}
+.badges {position:absolute;top:10px;left:10px;display:flex;flex-wrap:wrap;gap:6px;max-width:calc(100% - 20px);}
 .badge {background:rgba(255,255,255,0.1);border:1px solid rgba(255,255,255,0.2);border-radius:6px;font-size:.75rem;padding:4px 8px;}
-.case-content {padding:16px;}
-.case-title {font-size:1.1rem;margin-bottom:8px;}
-.case-quote {font-size:.95rem;color:#ccc;font-style:italic;}
+.case-content {padding:16px;display:flex;flex-direction:column;gap:8px;}
+.case-title {font-size:1.1rem;margin:0;word-break:break-word;}
+.case-quote {font-size:.95rem;color:#ccc;font-style:italic;margin:0;word-break:break-word;}
 .cta-all-cases {display:block;text-align:center;margin-top:32px;color:#e63946;text-decoration:none;font-weight:500;}
 .cta-all-cases:hover{text-decoration:underline;}
+
+.swiper-button-prev,
+.swiper-button-next {color:#fff;}
 
 .modal-overlay {position:fixed;inset:0;background:rgba(0,0,0,0.7);display:none;align-items:center;justify-content:center;z-index:1000;}
 .modal-overlay.active {display:flex;}
@@ -2257,7 +2262,15 @@ Assumptions (разумные допущения):
 .modal-phone {font-size:.9rem;margin-top:12px;text-align:center;}
 .modal-phone a {color:#e63946;text-decoration:none;}
 @keyframes fadeIn{from{opacity:0;transform:scale(.95);}to{opacity:1;transform:scale(1);}}
-@media(max-width:768px){.case-image{height:160px;}.section-title{font-size:1.6rem;}}
+@media(max-width:1024px){.cases-slider{padding-bottom:40px;}}
+@media(max-width:768px){
+  .section-title{font-size:1.6rem;}
+  .case-image{height:160px;}
+  .cases-slider{padding:0 4px 36px;}
+  .cases-slider .swiper-slide{width:min(88vw,360px);}
+  .swiper-pagination-bullets .swiper-pagination-bullet{background:rgba(255,255,255,0.6);}
+  .swiper-pagination-bullet-active{background:#e63946;}
+}
 </style>
 
 <script src="https://unpkg.com/swiper@10/swiper-bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- import Swiper bundle styles so the case carousel renders correctly on touch devices
- adjust case card layout to prevent content overflow and improve badge wrapping
- tune mobile slider sizing to keep slides within the viewport while enabling swiping

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69086452b990832fa067592d2ad19a91