### PR TITLE
Fix mobile swipe behavior for cases carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -2281,7 +2281,10 @@ const modal=document.querySelector('.modal-overlay');
 const cards=document.querySelectorAll('.case-card');
 const closeBtn=document.querySelector('.modal-close');
 
-cards.forEach(card=>{card.addEventListener('click',()=>{modal.classList.add('active');});});
+cards.forEach(card=>{card.addEventListener('click',()=>{
+  if(!swiper.allowClick)return;
+  modal.classList.add('active');
+});});
 closeBtn.addEventListener('click',()=>{modal.classList.remove('active');});
 modal.addEventListener('click',e=>{if(e.target===modal)modal.classList.remove('active');});
 </script>


### PR DESCRIPTION
## Summary
- prevent the modal trigger from firing while the cases slider is handling a swipe gesture

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_690865d4bb84832f86a97a679622bc95