### PR TITLE
Fix header overlap on hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,6 +156,7 @@
       const height = header.getBoundingClientRect().height;
       document.documentElement.style.setProperty('--header-height', `${height}px`);
       document.documentElement.style.setProperty('--header-offset', `${height}px`);
+      document.body.style.paddingTop = `${height}px`;
     }
 
     updateHeaderOffset();


### PR DESCRIPTION
## Summary
- update the header offset logic to also apply the measured height as body padding
- ensure the hero section always clears the fixed header on mobile devices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908cef33578832f9da6b8ceddd6af2b