### PR TITLE
Fix mobile header layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,13 +45,37 @@
       color: var(--text-0); border: none; cursor: pointer;
       transition: background var(--anim-mid) ease;
     }
-    .cta-primary { padding: 0 14px; background: var(--accent-yellow); color: #111; font-weight: 700; border-radius: 12px; width: auto; }
+    .cta-primary {
+      padding: 0 14px; background: var(--accent-yellow); color: #111; font-weight: 700; border-radius: 12px; width: auto;
+      min-height: 40px; text-align: center;
+    }
     .cta-primary.active {
        background: var(--accent-yellow);
        color: #111;
        box-shadow: 0 0 16px rgba(255,193,7,0.4);
      }
     .burger button:hover, .contact-icon:hover { background: rgba(255,255,255,0.1); }
+
+    @media (max-width: 640px) {
+      .header-inner { padding: 0 16px; }
+      .right { gap: 8px; }
+      .contact-icon { display: none; }
+      .cta-primary {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: auto;
+        min-width: 0;
+        min-height: 44px;
+        padding: 0 18px;
+        font-size: 15px;
+      }
+      .burger button {
+        width: 44px;
+        height: 44px;
+        background: rgba(255,255,255,0.08);
+      }
+    }
 
     /* Drawer */
     .mobile-drawer { position: fixed; top: 0; right: 0; bottom: 0; width: min(85vw,340px); background: #0E1116; transform: translateX(100%);


### PR DESCRIPTION
## Summary
- adjust the mobile header spacing to keep the burger button within the header bounds
- center the "Вызвать мастера" label and expand the CTA styling for small screens
- hide secondary contact icons on narrow viewports to avoid overflow

## Testing
- no automated tests run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_6908dcd6fe24832f95eb1b7a030f4fa4