### PR TITLE
Adjust mobile call-to-action width

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,8 +67,9 @@
         width: auto;
         min-width: 0;
         min-height: 44px;
-        padding: 0 18px;
-        font-size: 15px;
+        padding: 0 14px;
+        font-size: 14px;
+        white-space: nowrap;
       }
       .burger button {
         width: 44px;


### PR DESCRIPTION
## Summary
- reduce the padding and font size of the mobile "Вызвать мастера" button so it no longer touches the TireMasters title
- keep the label on a single line to avoid it growing too wide on small screens

## Testing
- not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_6908dff3a5d8832f85077f8f2cc0f92d