### PR TITLE
Center hero contact buttons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,6 +310,7 @@
 .btn-secondary:hover,.btn-secondary:focus{background:#1a1f27}
 
 .tm-hero__cta{display:flex;flex-wrap:wrap;gap:10px 14px;align-items:center;margin-bottom:14px;}
+.tm-hero__messengers{display:flex;align-items:center;gap:10px;}
 .messenger-btn{inline-size:42px;block-size:42px;display:grid;place-items:center;border-radius:50%;border:2px solid var(--steel);opacity:.9}
 .messenger-btn svg{width:22px;height:22px;stroke:var(--steel);stroke-width:2;fill:none}
 .tm-hero__note{font-size:13px;color:var(--muted);margin-top:6px}
@@ -339,7 +340,7 @@
 }
 @media (max-width: 720px){
   .tm-hero__container{grid-template-columns:1fr;padding:28px 0}
-  .tm-hero__cta{gap:10px}
+  .tm-hero__cta{gap:10px;justify-content:center;text-align:center}
   .tm-metrics{grid-template-columns:1fr}
   .tm-metric{grid-template-columns:1fr;justify-items:center;text-align:center}
   .tm-metric__icon{margin:0 auto 8px}


### PR DESCRIPTION
## Summary
- display hero messenger icons in a flex row so they stay horizontal
- center the hero CTA row on narrow screens for balanced mobile layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6908e4dc406c832f8721830e6c3a9edc