### PR TITLE
Adjust mobile comment field height

### DIFF
--- a/index.html
+++ b/index.html
@@ -516,7 +516,7 @@ const HERO_FRAMES = [
             <p class="err" id="err-phone" hidden>Введите телефон</p>
           </label>
 
-          <label class="tm-input">
+          <label class="tm-input tm-input--control">
             <span>Комментарий</span>
             <input type="text" name="comment" placeholder="Пожелания, подъезд, секретки…">
             <svg class="ico" viewBox="0 0 24 24" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>


### PR DESCRIPTION
## Summary
- update the comment field in the calculator form to use the same control styling classes as other inputs
- ensures the comment section matches the height of other fields on mobile layouts

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_6908eb756998832fb78764bcdb81832e