### PR TITLE
Switch section separators to gray divider

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,16 +124,13 @@
       position: relative;
       display: block;
       width: 100%;
-      height: 12px;
-      background-image: repeating-linear-gradient(
-        135deg,
-        rgba(120, 126, 138, 0.92) 0 28px,
-        rgba(70, 75, 86, 0.92) 28px 56px
+      height: 1px;
+      background: linear-gradient(
+        90deg,
+        rgba(120, 126, 138, 0.45) 0%,
+        rgba(86, 92, 105, 0.45) 100%
       );
-      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), inset 0 -1px 0 rgba(0, 0, 0, 0.5);
-      border-top: 1px solid rgba(255, 255, 255, 0.06);
-      border-bottom: 1px solid rgba(0, 0, 0, 0.55);
-      overflow: hidden;
+      box-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- restyle the `.tm-section-tape` separators to display as a subtle gray hairline divider instead of the previous caution tape pattern

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69091efda064832f86408c8a09dc957b