### PR TITLE
Remove divider between hero and calculator sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -627,7 +627,7 @@ const HERO_FRAMES = [
 .tm-calc{position:relative;isolation:isolate;color:var(--white);padding:56px 0;scroll-margin-top:88px;}
 /* Декоративные разделители как в Hero */
 .tm-calc::before,.tm-calc::after{content:"";position:absolute;left:0;right:0;height:22px;pointer-events:none}
-.tm-calc::before{top:0;background-image:url("data:image/svg+xml,%3Csvg width='160' height='22' viewBox='0 0 160 22' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%238D99A733' d='M0 22L40 0l40 22 40-22 40 22H0z'/%3E%3C/svg%3E");background-repeat:repeat;background-size:auto 22px}
+.tm-calc::before{display:none}
 .tm-calc::after{bottom:0;background-image:url("data:image/svg+xml,%3Csvg width='160' height='22' viewBox='0 0 160 22' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%238D99A733' d='M0 0h160v4H0zm0 9h160v4H0zm0 9h160v4H0z'/%3E%3C/svg%3E");background-repeat:repeat;background-size:auto 22px}
 
 /* Фон и маска */


### PR DESCRIPTION
## Summary
- hide the decorative top divider on the calculator section so the hero and calculator blocks sit flush

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690985a5d9bc832fb56e5ef59f821803