### PR TITLE
Add consistent dividers between landing sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -946,6 +946,8 @@ const HERO_FRAMES = [
 </section>
 <!-- TM-MARK: КАЛЬКУЛЯТОР END -->
 
+<div class="tm-section-divider" aria-hidden="true"></div>
+
 <!DOCTYPE html>
 <html lang="ru">
 <head>
@@ -1302,6 +1304,8 @@ const HERO_FRAMES = [
   </section>
   <!-- TM-MARK: SERVICES_BLOCK END -->
 
+  <div class="tm-section-divider" aria-hidden="true"></div>
+
   <!-- Anchor target for "Почему мы" navigation item -->
   <div id="why" class="tm-anchor" aria-hidden="true"></div>
 </body>
@@ -1553,6 +1557,8 @@ const HERO_FRAMES = [
 })();
 // TM-MARK: HOW-IT-WORKS JS END
 </script>
+
+<div class="tm-section-divider" aria-hidden="true"></div>
 
 <!-- TM-MARK: BLOCK PRICE (ONE FILE) -->
 <!DOCTYPE html>
@@ -1952,6 +1958,8 @@ const HERO_FRAMES = [
 </html>
 <!-- TM-MARK: BLOCK PRICE END -->
 
+<div class="tm-section-divider" aria-hidden="true"></div>
+
 <!--
 Assumptions (разумные допущения):
 1) Количество направлений ЛО — 6 южных направлений (если нужно, заменю на точный список).
@@ -2203,6 +2211,8 @@ Assumptions (разумные допущения):
 </body>
 </html>
 
+<div class="tm-section-divider" aria-hidden="true"></div>
+
 <!-- TM-MARK: CASES SECTION START -->
 <!-- Исправления:
 1. Кнопка закрытия модалки теперь корректно работает (правильный селектор и обработчик событий).
@@ -2369,6 +2379,8 @@ Assumptions (разумные допущения):
 })();
 </script>
 <!-- TM-MARK: CASES SECTION END -->
+
+<div class="tm-section-divider" aria-hidden="true"></div>
 
 <!-- TM-MARK: START -->
 <!DOCTYPE html>
@@ -2704,6 +2716,8 @@ Assumptions (разумные допущения):
 </html>
 <!-- TM-MARK: END -->
 
+<div class="tm-section-divider" aria-hidden="true"></div>
+
 <!-- TM-MARK:START -->
 <!doctype html>
 <html lang="ru">
@@ -2767,6 +2781,8 @@ document.querySelectorAll('.toggle-btn').forEach(btn=>{
 </body>
 </html>
 <!-- TM-MARK:END -->
+
+<div class="tm-section-divider" aria-hidden="true"></div>
 
 <style>
 body {
@@ -2922,6 +2938,8 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 </script>
 <!-- TM-MARK: СПЕЦПРЕДЛОЖЕНИЕ END -->
+
+<div class="tm-section-divider" aria-hidden="true"></div>
 
 <!-- TM-MARK: КОНТАКТЫ START -->
 <section class="contacts-section" id="contacts">


### PR DESCRIPTION
## Summary
- add the existing `tm-section-divider` markup between each major landing section so every block gets the same separator treatment
- leave the transition to the footer untouched to preserve its existing decorative border

## Testing
- not run (markup-only change)


------
https://chatgpt.com/codex/tasks/task_e_690a632027a0832f8dafdf9ddf038d52