### PR TITLE
Adjust price table typography for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -1714,6 +1714,15 @@ const HERO_FRAMES = [
     .price-val{ white-space:nowrap; font-weight:700; color:#fff; }
     .price-val .rub{ opacity:.95; font-weight:600; }
 
+    @media (max-width: 480px){
+      table.price-table{ min-width:100%; }
+      thead th,
+      tbody td{ font-size:13px; padding:10px 12px; }
+      .svc-name{ font-size:13px; gap:8px; }
+      .svc-note{ font-size:11px; }
+      .price-val{ font-size:13px; }
+    }
+
     /* Бейджи/подсказки */
     .badge{ display:inline-flex; align-items:center; gap:6px; 
       padding:6px 10px; border-radius:999px; font-size:12px; font-weight:700;


### PR DESCRIPTION
## Summary
- reduce type scale and padding within the price table for small screens
- allow the table to shrink to the mobile viewport width to avoid horizontal scrolling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690a6e705db8832f991f7f8f96dc7e52