### PR TITLE
Add tow section link to header navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,7 @@
       <li><a href="#hero">Hero</a></li>
       <li><a href="#calc">Калькулятор</a></li>
       <li><a href="#services">Услуги</a></li>
+      <li><a href="#tow-anchor">Эвакуатор</a></li>
       <li><a href="#why">Почему мы</a></li>
       <li><a href="#how">Как это работает</a></li>
       <li><a href="#price">Прайс</a></li>
@@ -947,6 +948,8 @@ const HERO_FRAMES = [
 <!-- TM-MARK: КАЛЬКУЛЯТОР END -->
 
 <div class="tm-section-divider" aria-hidden="true"></div>
+
+<div id="tow-anchor" class="tm-anchor" aria-hidden="true"></div>
 
 <!-- TM-MARK: ЭВАКУАТОР START -->
 <section id="tow" class="tm-tow" aria-label="Эвакуатор 24/7 в Санкт-Петербурге и ЛО">


### PR DESCRIPTION
## Summary
- add an "Эвакуатор" item to the mobile drawer navigation in the header
- insert an anchor before the tow section so the new navigation item scrolls correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690ad3e74d2c832f892e6b5c19e43964