### PR TITLE
Adjust mobile drawer navigation labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,13 +148,16 @@
   </header>
 
   <aside class="mobile-drawer" id="mobileDrawer">
-    <button class="contact-icon" id="closeDrawer" aria-label="Закрыть меню">✕</button>
+    <button class="contact-icon" id="closeDrawer" aria-label="Скрыть меню" title="Скрыть меню">
+      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <path d="M6 14.5 12 8.5l6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </button>
     <ul>
-      <li><a href="#hero">Hero</a></li>
+      <li><a href="#hero">Главная</a></li>
       <li><a href="#calc">Калькулятор</a></li>
       <li><a href="#tow-anchor">Эвакуатор</a></li>
       <li><a href="#services">Услуги</a></li>
-      <li><a href="#why">Почему мы</a></li>
       <li><a href="#how">Как это работает</a></li>
       <li><a href="#price">Прайс</a></li>
       <li><a href="#geo">География</a></li>


### PR DESCRIPTION
## Summary
- rename the Hero navigation link to Главная and remove the Почему мы entry
- replace the drawer close button with an arrow icon that hides the menu on click

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690ae1430a4c832f90163856c032746d