### PR TITLE
Add auto electrician link to header navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
       <li><a href="#hero">Главная</a></li>
       <li><a href="#calc">Калькулятор</a></li>
       <li><a href="#tow-anchor">Эвакуатор</a></li>
+      <li><a href="#electrician-anchor">Автоэлектрик</a></li>
       <li><a href="#services">Услуги</a></li>
       <li><a href="#how">Как это работает</a></li>
       <li><a href="#price">Прайс</a></li>
@@ -1112,6 +1113,8 @@ const HERO_FRAMES = [
 <!-- TM-MARK: ЭВАКУАТОР END -->
 
 <div class="tm-section-divider" aria-hidden="true"></div>
+
+<div id="electrician-anchor" class="tm-anchor" aria-hidden="true"></div>
 
 <!-- TM-MARK: ELECTRICIAN START -->
 <section id="out-electrician" class="tm-electrician" aria-labelledby="electrician-title">


### PR DESCRIPTION
## Summary
- add an auto electrician link to the header drawer menu between the tow truck and services items
- insert an offset anchor for the auto electrician section so the fixed header does not cover it when navigated to

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c29ab4318832f9726244a5e08a783