### PR TITLE
Update TireMasters contact info to new official channels

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,10 +135,10 @@
     <div class="header-inner">
       <a href="#hero" class="brand"><img src="assets/logo.png" alt="Логотип"/><span>TireMasters</span></a>
       <div class="right">
-        <a class="contact-icon" href="https://t.me/tiremasters_spb" target="_blank" aria-label="Telegram">
+        <a class="contact-icon" href="https://t.me/Tiar_MASTERSPro" target="_blank" aria-label="Telegram">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.5 13.2L9.3 17.1l3-2.3 4.4 3.2 2.9-13.7L3 9.2l4.6 1.4 10.7-6.7L9.5 13.2z" fill="currentColor"/></svg>
         </a>
-        <a class="contact-icon" href="tel:+79211234567" aria-label="Позвонить">
+        <a class="contact-icon" href="tel:+79531580900" aria-label="Позвонить">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.6 10.8c1.3 2.5 3.2 4.5 5.7 5.7l1.9-1.9c.3-.3.8-.4 1.2-.3 1 .3 2 .4 3.1.4.6 0 1 .4 1 .9v3.1c0 .6-.4 1-.9 1C10.9 20 4 13.1 4 4.9c0-.5.4-.9 1-.9H8c.6 0 1 .4 1 .9 0 1 .1 2.1.4 3.1.1.4 0 .9-.3 1.2l-1.9 1.5z" fill="currentColor"/></svg>
         </a>
         <a class="cta-primary active" href="#calc">Вызвать мастера</a>
@@ -238,13 +238,13 @@
 
       <div class="tm-hero__cta">
         <a href="#calc" class="btn btn-primary-outline" aria-label="Вызвать мастера — перейти к калькулятору">Вызвать мастера</a>
-        <a href="tel:+79211234567" class="btn btn-secondary" aria-label="Позвонить в TireMasters">Позвонить</a>
+        <a href="tel:+79531580900" class="btn btn-secondary" aria-label="Позвонить в TireMasters">Позвонить</a>
         <div class="tm-hero__messengers" role="group" aria-label="Мессенджеры">
-          <a class="messenger-btn" href="https://wa.me/79211234567" target="_blank" rel="noopener" aria-label="Написать в WhatsApp" title="WhatsApp">
+          <a class="messenger-btn" href="https://wa.me/79531580900" target="_blank" rel="noopener" aria-label="Написать в WhatsApp" title="WhatsApp">
             <!-- WA icon -->
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17.47 14.33c-.28-.14-1.66-.8-1.92-.9-.26-.1-.46-.14-.66.14-.2.28-.76.9-.94 1.08-.18.18-.34.2-.62.06-.28-.14-1.16-.43-2.2-1.38-.81-.72-1.36-1.6-1.52-1.88-.16-.28-.02-.44.12-.58.12-.12.28-.32.42-.48.14-.16.18-.28.28-.46.1-.18.06-.34-.02-.48-.08-.14-.66-1.58-.9-2.16-.24-.58-.48-.5-.66-.5-.18 0-.38-.02-.58-.02s-.54.08-.82.38c-.28.3-1.08 1.06-1.08 2.58 0 1.52 1.1 2.98 1.26 3.18.16.2 2.16 3.3 5.22 4.54.73.3 1.3.48 1.74.62.73.24 1.38.2 1.9.12.58-.08 1.78-.72 2.04-1.42.26-.7.26-1.3.2-1.42-.06-.12-.54-1.3-.74-1.78-.2-.48-.4-.42-.58-.42Z"/></svg>
           </a>
-          <a class="messenger-btn" href="https://t.me/TireMasters" target="_blank" rel="noopener" aria-label="Написать в Telegram" title="Telegram">
+          <a class="messenger-btn" href="https://t.me/Tiar_MASTERSPro" target="_blank" rel="noopener" aria-label="Написать в Telegram" title="Telegram">
             <!-- TG icon -->
             <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M21.44 3.2 2.35 10.63c-.86.35-.86 1.64.1 1.97l4.86 1.6 1.87 6.07c.24.78 1.22.86 1.66.14l2.67-4.33 4.9 3.66c.77.57 1.86.14 2.06-.82l-.34-14.1Z"/></svg>
           </a>
@@ -591,19 +591,19 @@ const HERO_FRAMES = [
 
       <!-- TM-MARK: CTA В ПРАВОЙ КОЛОНКЕ START -->
       <div class="tm-cta-corner" role="region" aria-label="Быстрые действия (в правой колонке)">
-    <a class="cta-btn cta-primary" href="tel:+79211234567" aria-label="Позвонить в TireMasters">
+    <a class="cta-btn cta-primary" href="tel:+79531580900" aria-label="Позвонить в TireMasters">
       <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.11 4.2 2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.72c.12.9.3 1.78.57 2.63a2 2 0 0 1-.45 2.11L8.1 9.1a16 16 0 0 0 6 6l.64-1.12a2 2 0 0 1 2.11-.45c.85.27 1.73.45 2.63.57A2 2 0 0 1 22 16.92z"/></svg></span>
-      <span class="txt"><strong>Позвонить</strong><em>+7 (921) 123-45-67</em></span>
+      <span class="txt"><strong>Позвонить</strong><em>+7 953 158 0900</em></span>
     </a>
     <a class="cta-btn cta-accent" href="#calc" aria-label="Вызвать шиномонтаж — перейти к форме">
       <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M7 12h10M12 7v10"/></svg></span>
       <span class="txt"><strong>Вызвать шиномонтаж</strong><em>оформить заявку</em></span>
     </a>
-    <a class="cta-btn" href="https://t.me/TireMasters" target="_blank" rel="noopener" aria-label="Написать в Telegram">
+    <a class="cta-btn" href="https://t.me/Tiar_MASTERSPro" target="_blank" rel="noopener" aria-label="Написать в Telegram">
       <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M21.44 3.2 2.35 10.63c-.86.35-.86 1.64.1 1.97l4.86 1.6 1.87 6.07c.24.78 1.22.86 1.66.14l2.67-4.33 4.9 3.66c.77.57 1.86.14 2.06-.82l-.34-14.1Z"/></svg></span>
-      <span class="txt"><strong>Telegram</strong><em>@TireMasters</em></span>
+      <span class="txt"><strong>Telegram</strong><em>@Tiar_MASTERSPro</em></span>
     </a>
-    <a class="cta-btn" href="https://wa.me/79211234567" target="_blank" rel="noopener" aria-label="Написать в WhatsApp">
+    <a class="cta-btn" href="https://wa.me/79531580900" target="_blank" rel="noopener" aria-label="Написать в WhatsApp">
       <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M17.47 14.33c-.28-.14-1.66-.8-1.92-.9-.26-.1-.46-.14-.66.14-.2.28-.76.9-.94 1.08-.18.18-.34.2-.62.06-.28-.14-1.16-.43-2.2-1.38-.81-.72-1.36-1.6-1.52-1.88-.16-.28-.02-.44.12-.58.12-.12.28-.32.42-.48.14-.16.18-.28.28-.46.1-.18.06-.34-.02-.48-.08-.14-.66-1.58-.9-2.16-.24-.58-.48-.5-.66-.5-.18 0-.38-.02-.58-.02s-.54.08-.82.38c-.28.3-1.08 1.06-1.08 2.58 0 1.52 1.1 2.98 1.26 3.18.16.2 2.16 3.3 5.22 4.54.73.3 1.3.48 1.74.62.73.24 1.38.2 1.9.12.58-.08 1.78-.72 2.04-1.42.26-.7.26-1.3.2-1.42-.06-.12-.54-1.3-.74-1.78-.2-.48-.4-.42-.58-.42Z"/></svg></span>
       <span class="txt"><strong>WhatsApp</strong><em>написать</em></span>
     </a>
@@ -1005,12 +1005,12 @@ const HERO_FRAMES = [
 
     <div class="tm-tow__cta">
       <a href="#tow-form" class="btn btn-primary-outline">Вызвать эвакуатор</a>
-      <a href="tel:+79211234567" class="btn btn-secondary">Позвонить</a>
+      <a href="tel:+79531580900" class="btn btn-secondary">Позвонить</a>
       <div class="tm-tow__messengers">
-        <a class="messenger-btn" href="https://t.me/TireMasters" target="_blank" aria-label="Telegram">
+        <a class="messenger-btn" href="https://t.me/Tiar_MASTERSPro" target="_blank" aria-label="Telegram">
           <svg viewBox="0 0 24 24"><path d="M21.44 3.2 2.35 10.63c-.86.35-.86 1.64.1 1.97l4.86 1.6 1.87 6.07c.24.78 1.22.86 1.66.14l2.67-4.33 4.9 3.66c.77.57 1.86.14 2.06-.82l-.34-14.1Z"/></svg>
         </a>
-        <a class="messenger-btn" href="https://wa.me/79211234567" target="_blank" aria-label="WhatsApp">
+        <a class="messenger-btn" href="https://wa.me/79531580900" target="_blank" aria-label="WhatsApp">
           <svg viewBox="0 0 24 24"><path d="M17.47 14.33c-.28-.14-1.66-.8-1.92-.9-.26-.1-.46-.14-.66.14-.2.28-.76.9-.94 1.08-.18.18-.34.2-.62.06-.28-.14-1.16-.43-2.2-1.38-.81-.72-1.36-1.6-1.52-1.88-.16-.28-.02-.44.12-.58.12-.12.28-.32.42-.48.14-.16.18-.28.28-.46.1-.18.06-.34-.02-.48-.08-.14-.66-1.58-.9-2.16-.24-.58-.48-.5-.66-.5-.18 0-.38-.02-.58-.02s-.54.08-.82.38c-.28.3-1.08 1.06-1.08 2.58 0 1.52 1.1 2.98 1.26 3.18.16.2 2.16 3.3 5.22 4.54.73.3 1.3.48 1.74.62.73.24 1.38.2 1.9.12.58-.08 1.78-.72 2.04-1.42.26-.7.26-1.3.2-1.42-.06-.12-.54-1.3-.74-1.78-.2-.48-.4-.42-.58-.42Z"/></svg>
         </a>
       </div>
@@ -1129,7 +1129,7 @@ const HERO_FRAMES = [
       <p class="tm-electrician__lead">Приедем к вам, когда машина не заводится, села батарея или отказала электроника. Поможем на дороге, во дворе или в гаражном комплексе.</p>
       <div class="tm-electrician__cta">
         <a class="tm-electrician__cta-btn" href="#electrician-form" aria-label="Перейти к форме заявки на выезд автоэлектрика">Вызвать мастера</a>
-        <p class="tm-electrician__cta-note">или позвоните <a href="tel:+79211234567">+7&nbsp;921&nbsp;123‑45‑67</a></p>
+        <p class="tm-electrician__cta-note">или позвоните <a href="tel:+79531580900">+7&nbsp;953&nbsp;158&nbsp;0900</a></p>
       </div>
     </header>
 
@@ -1183,7 +1183,7 @@ const HERO_FRAMES = [
 
       <section class="tm-electrician__contacts" aria-labelledby="electrician-contacts-title">
         <h3 id="electrician-contacts-title">Контакты и география</h3>
-        <p><strong>Телефон:</strong> <a href="tel:+79211234567">+7&nbsp;921&nbsp;123‑45‑67</a></p>
+        <p><strong>Телефон:</strong> <a href="tel:+79531580900">+7&nbsp;953&nbsp;158&nbsp;0900</a></p>
         <p><strong>Покрытие:</strong> Все районы Санкт-Петербурга и ближайшие города ЛО.</p>
         <p><strong>График:</strong> ежедневно, 08:00–23:00, экстренный выезд 24/7.</p>
       </section>
@@ -2951,7 +2951,7 @@ Assumptions (разумные допущения):
         <input type="tel" placeholder="Ваш телефон" required aria-label="Телефон">
         <button type="submit">Отправить заявку</button>
       </form>
-      <p class="modal-phone">или позвоните напрямую: <a href="tel:+79000000000">+7 900 000-00-00</a></p>
+      <p class="modal-phone">или позвоните напрямую: <a href="tel:+79531580900">+7 953 158 0900</a></p>
     </div>
   </div>
 </section>
@@ -3597,12 +3597,12 @@ document.addEventListener("DOMContentLoaded", () => {
     <h2 class="contacts-title">Связаться с TireMasters</h2>
     <p class="contacts-subtitle">Ответим в мессенджере за 5–10 минут</p>
 
-    <p class="contacts-phone">Позвонить: <a href="tel:+79211234567">+7 (921) 123-45-67</a></p>
+    <p class="contacts-phone">Позвонить: <a href="tel:+79531580900">+7 953 158 0900</a></p>
 
     <div class="contacts-buttons">
-      <a href="tel:+79211234567" class="btn primary">Позвонить</a>
-      <a href="https://wa.me/79211234567" target="_blank" class="btn secondary">Написать в WhatsApp</a>
-      <a href="https://t.me/tiremasters" target="_blank" class="btn secondary">Написать в Telegram</a>
+      <a href="tel:+79531580900" class="btn primary">Позвонить</a>
+      <a href="https://wa.me/79531580900" target="_blank" class="btn secondary">Написать в WhatsApp</a>
+      <a href="https://t.me/Tiar_MASTERSPro" target="_blank" class="btn secondary">Написать в Telegram</a>
     </div>
 
     <p class="contacts-alt-text">Или оставьте заявку через калькулятор ниже</p>
@@ -3977,12 +3977,12 @@ document.addEventListener("DOMContentLoaded", () => {
         </div>
 
         <div class="tm-socials" aria-label="Соцканалы и мессенджеры">
-          <a class="focusable" href="https://t.me/your_channel" target="_blank" rel="noopener" aria-label="Наш Telegram‑канал (откроется в новой вкладке)">
+          <a class="focusable" href="https://t.me/Tiar_MASTERSPro" target="_blank" rel="noopener" aria-label="Наш Telegram‑канал (откроется в новой вкладке)">
             <!-- Telegram icon -->
             <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M9.04 15.47l-.38 5.36c.54 0 .78-.23 1.06-.5l2.55-2.43 5.28 3.86c.97.54 1.66.26 1.93-.9l3.5-16.44.01-.01c.31-1.43-.52-1.99-1.46-1.64L1.76 9.5c-1.4.54-1.38 1.32-.24 1.67l5.28 1.65 12.27-7.74c.58-.36 1.11-.16.68.2z"/></svg>
             Telegram‑канал
           </a>
-          <a class="focusable" href="https://t.me/your_chat" target="_blank" rel="noopener" aria-label="Наш Telegram‑чат (откроется в новой вкладке)">
+          <a class="focusable" href="https://t.me/Tiar_MASTERSPro" target="_blank" rel="noopener" aria-label="Наш Telegram‑чат (откроется в новой вкладке)">
             <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M9.04 15.47l-.38 5.36c.54 0 .78-.23 1.06-.5l2.55-2.43 5.28 3.86c.97.54 1.66.26 1.93-.9l3.5-16.44.01-.01c.31-1.43-.52-1.99-1.46-1.64L1.76 9.5c-1.4.54-1.38 1.32-.24 1.67l5.28 1.65 12.27-7.74c.58-.36 1.11-.16.68.2z"/></svg>
             Telegram‑чат
           </a>
@@ -3993,21 +3993,21 @@ document.addEventListener("DOMContentLoaded", () => {
       <div class="tm-footer__right">
         <section class="tm-cta" aria-labelledby="tm-cta-title">
           <h2 class="tm-sr-only" id="tm-cta-title">Связаться с TireMasters</h2>
-          <p class="tm-cta__phone"><a class="focusable" href="tel:+7XXXXXXXXXX" data-action="call-primary">+7 (921) 123‑45‑67</a></p>
+          <p class="tm-cta__phone"><a class="focusable" href="tel:+79531580900" data-action="call-primary">+7 953 158 0900</a></p>
           <p class="tm-cta__hint">Мы на связи 24/7. Звоните — приедем быстро.</p>
 
           <div class="tm-cta__actions">
-            <a class="tm-btn tm-btn--primary focusable" href="tel:+7XXXXXXXXXX" data-action="call-cta" aria-label="Вызвать мастера по телефону">
+            <a class="tm-btn tm-btn--primary focusable" href="tel:+79531580900" data-action="call-cta" aria-label="Вызвать мастера по телефону">
               <!-- phone icon -->
               <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M6.6 10.8a15.5 15.5 0 006.6 6.6l2.2-2.2a1.5 1.5 0 011.5-.37 9.6 9.6 0 003 0.5 1.5 1.5 0 011.3 1.5V20a2 2 0 01-2 2A16 16 0 012 8a2 2 0 012-2h3.2a1.5 1.5 0 011.5 1.3 9.6 9.6 0 00.5 3 1.5 1.5 0 01-.37 1.5z"/></svg>
               Вызвать мастера
             </a>
-            <a class="tm-btn tm-btn--ghost focusable" href="https://wa.me/7XXXXXXXXXX" target="_blank" rel="noopener" aria-label="Написать в WhatsApp (откроется в новой вкладке)">
+            <a class="tm-btn tm-btn--ghost focusable" href="https://wa.me/79531580900" target="_blank" rel="noopener" aria-label="Написать в WhatsApp (откроется в новой вкладке)">
               <!-- WhatsApp icon -->
               <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M20.5 3.5A11.9 11.9 0 0012 1 11 11 0 001 12a11 11 0 001.6 5.8L1 23l5.4-1.5A11 11 0 0012 23a11 11 0 0011-11 11.5 11.5 0 00-2.5-8.5zM12 21a9 9 0 01-4.6-1.3l-.3-.2-3.2.9.9-3.1-.2-.3A9 9 0 1112 21zm5-6.7c-.3-.1-1.8-.9-2.1-1s-.5-.1-.7.1l-.5.6c-.2.2-.4.2-.6.1a7.6 7.6 0 01-3.5-3.1c-.2-.3 0-.5.1-.6l.4-.4c.1-.2.2-.3.1-.6 0-.1-.7-1.8-.9-2.1s-.4-.3-.6-.3h-.5a1 1 0 00-.7.3 2.8 2.8 0 00-.9 2.1 5 5 0 001 2.6 11.5 11.5 0 004.5 4.4 7.8 7.8 0 002.6 1 2.2 2.2 0 002.1-.9 1 1 0 00.3-.7v-.5c0-.2 0-.5-.3-.6z"/></svg>
               WhatsApp
             </a>
-            <a class="tm-btn tm-btn--ghost focusable" href="https://t.me/your_chat" target="_blank" rel="noopener" aria-label="Написать в Telegram (откроется в новой вкладке)">
+            <a class="tm-btn tm-btn--ghost focusable" href="https://t.me/Tiar_MASTERSPro" target="_blank" rel="noopener" aria-label="Написать в Telegram (откроется в новой вкладке)">
               <!-- Telegram icon -->
               <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M9.04 15.47l-.38 5.36c.54 0 .78-.23 1.06-.5l2.55-2.43 5.28 3.86c.97.54 1.66.26 1.93-.9l3.5-16.44.01-.01c.31-1.43-.52-1.99-1.46-1.64L1.76 9.5c-1.4.54-1.38 1.32-.24 1.67l5.28 1.65 12.27-7.74c.58-.36 1.11-.16.68.2z"/></svg>
               Telegram
@@ -4051,19 +4051,25 @@ document.addEventListener("DOMContentLoaded", () => {
        ============================= */
     // Example: swap all tel/placeholders quickly in one place
     (function() {
-      var TEL_HUMAN = '+7 (921) 123‑45‑67';
-      var TEL_LINK = '+7XXXXXXXXXX'; // Replace with digits only e.g. +79211234567
-      var WA_LINK = 'https://wa.me/7XXXXXXXXXX';
-      var TG_CHAT = 'https://t.me/your_chat';
-      var TG_CHANNEL = 'https://t.me/your_channel';
+      var TEL_HUMAN = '+7 953 158 0900';
+      var TEL_LINK = '+79531580900';
+      var WA_LINK = 'https://wa.me/79531580900';
+      var TG_LINK = 'https://t.me/Tiar_MASTERSPro';
 
       // Apply if someone forgets to update in HTML
-      document.querySelectorAll('[data-action="call-primary"]').forEach(function(a){ a.textContent = TEL_HUMAN; a.href = 'tel:' + TEL_LINK; });
-      document.querySelectorAll('[data-action="call-cta"]').forEach(function(a){ a.href = 'tel:' + TEL_LINK; });
+      document.querySelectorAll('[data-action="call-primary"]').forEach(function(a){
+        a.textContent = TEL_HUMAN;
+        a.href = 'tel:' + TEL_LINK;
+      });
+      document.querySelectorAll('[data-action="call-cta"]').forEach(function(a){
+        a.href = 'tel:' + TEL_LINK;
+      });
       // Socials quick guard (non-breaking if not present)
-      var wa = document.querySelector('a[href^="https://wa.me/"]'); if (wa) wa.href = WA_LINK;
+      document.querySelectorAll('a[href^="https://wa.me/"]').forEach(function(a){
+        a.href = WA_LINK;
+      });
       document.querySelectorAll('a[href^="https://t.me/"]').forEach(function(a){
-        if (a.textContent.includes('канал')) a.href = TG_CHANNEL; else a.href = TG_CHAT;
+        a.href = TG_LINK;
       });
     })();
     /* ===========================


### PR DESCRIPTION
## Summary
- replace every phone link and displayed number with +7 953 158 0900 across the site
- update WhatsApp and Telegram buttons, icons, and fallback script to use the current accounts

## Testing
- not run (not required)


------
https://chatgpt.com/codex/tasks/task_e_690d0f750dbc832f92ab6e09d6a14666