### PR TITLE
Adjust mobile layout for calculator services

### DIFF
--- a/index.html
+++ b/index.html
@@ -774,7 +774,7 @@ const HERO_FRAMES = [
 .tm-fieldset legend{padding:0 6px;color:var(--steel);font-size:13px}
 
 /* Сетка услуг (иконки-карточки) */
-.tm-service-grid{display:grid;grid-template-columns:1fr;gap:8px}
+.tm-service-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
 .service-card{display:grid;grid-template-columns:auto 1fr;grid-auto-rows:auto;gap:4px 10px;align-items:center;padding:8px 12px;border:1px solid rgba(255,255,255,.1);border-radius:12px;background:rgba(20,24,28,.5);cursor:pointer;transition:transform var(--t), border-color var(--t), background var(--t);min-height:72px}
 .service-card input{display:none}
 .service-card .icon{grid-row:1/span 2;width:34px;height:34px;border-radius:50%;display:grid;place-items:center;border:1.5px solid var(--yellow);background:rgba(255,197,44,.08);color:var(--yellow);}
@@ -846,8 +846,8 @@ const HERO_FRAMES = [
 @media (max-width: 1024px){
   .tm-calc__container{grid-template-columns:1fr}
 }
-@media (min-width: 481px){
-  .tm-service-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
+@media (max-width: 359px){
+  .tm-service-grid{grid-template-columns:1fr}
 }
 
 @media (max-width: 720px){


### PR DESCRIPTION
## Summary
- update the calculator service grid to show two columns by default for mobile viewports
- add a narrow-screen fallback that keeps cards readable on very small devices

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f0b938f14832f9fc1ad90e6574285)