### PR TITLE
Fix calculator service card styling to restore two-column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,151 +461,151 @@ const HERO_FRAMES = [
         <fieldset class="tm-fieldset">
           <legend>Выберите услугу <span aria-hidden="true">*</span></legend>
           <div class="tm-service-grid" role="group" aria-label="Услуга">
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="repair-puncture" required>
               <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 7v10M7 12h10"/></svg></span>
               <span class="title">Ремонт проколов</span>
               <span class="hint">Шиномонтаж</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="sidewall-repair" required>
               <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9 9l6 6"/></svg></span>
               <span class="title">Ремонт боковых порезов</span>
               <span class="hint">Шиномонтаж</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="hernia-repair" required>
               <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><circle cx="12" cy="12" r="4"/></svg></span>
               <span class="title">Ремонт грыж</span>
               <span class="hint">Шиномонтаж</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="spare-install" required>
               <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M5 12h14"/></svg></span>
               <span class="title">Установка запаски</span>
               <span class="hint">Шиномонтаж</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="tire-change" required>
               <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M6 5h12l2 7-2 7H6L4 12l2-7Z"/></svg></span>
               <span class="title">Замена резины</span>
               <span class="hint">Шиномонтаж</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="stud-install" required>
               <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M9 9h6v6H9z"/></svg></span>
               <span class="title">Дошиповка шин</span>
               <span class="hint">Шиномонтаж</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="rim-straightening" required>
               <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M8 8l8 8"/></svg></span>
               <span class="title">Правка дисков</span>
               <span class="hint">Шиномонтаж</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="tire-storage" required>
               <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 7h16v10H4z"/><path d="M4 11h16"/></svg></span>
               <span class="title">Хранение шин</span>
               <span class="hint">Шиномонтаж</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="lock-removal" required>
               <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M10 10h4v4h-4z"/></svg></span>
               <span class="title">Снятие секреток</span>
               <span class="hint">Шиномонтаж</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="computer-diagnostics" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="12" rx="2"/><path d="M12 16v4"/><path d="M8 20h8"/></svg></span>
               <span class="title">Компьютерная диагностика</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="engine-start" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M6 13l6-10 6 10h-5l5 9-11-9h5z"/></svg></span>
               <span class="title">Запуск двигателя</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="engine-diagnostics" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M3 12h3l3 7 4-14 4 7h4"/></svg></span>
               <span class="title">Диагностика двигателя</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="battery-replacement" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><rect x="3" y="7" width="18" height="10" rx="2"/><path d="M7 4v3M17 4v3"/></svg></span>
               <span class="title">Замена аккумулятора</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="truck-electric" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M3 13h13V6H3z"/><path d="M16 10h4l1 3v5h-5z"/><circle cx="7" cy="18" r="2"/><circle cx="18" cy="18" r="2"/></svg></span>
               <span class="title">Грузовой автоэлектрик</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="jump-start" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M7 7h4l-2 5h4l-3 7"/></svg></span>
               <span class="title">Прикурить автомобиль</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="odometer-correction" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 12a8 8 0 1 1 16 0"/><path d="M12 4v8l4 2"/></svg></span>
               <span class="title">Скрутить пробег</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="alarm-disable" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M5 10V7a7 7 0 0 1 14 0v3"/><rect x="4" y="10" width="16" height="11" rx="2"/></svg></span>
               <span class="title">Отключение сигнализации</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="key-making" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M7 7a5 5 0 1 1 5 5l-2 2v3H8v-2H6v-2H5"/></svg></span>
               <span class="title">Изготовление ключей</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="wiring-repair" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 7h4v10H4z"/><path d="M10 7h4v10h-4z"/><path d="M16 7h4v10h-4z"/></svg></span>
               <span class="title">Ремонт проводки</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="alternator-repair" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"/><path d="M12 4v8l4 4"/></svg></span>
               <span class="title">Ремонт генераторов</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="starter-repair" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M5 6h9l5 6-5 6H5z"/></svg></span>
               <span class="title">Ремонт стартеров</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="immobilizer-disable" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="8" r="4"/><path d="M5 12h14v8H5z"/></svg></span>
               <span class="title">Отключение иммобилайзера</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="immobilizer-flash" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M5 5h14v4H5z"/><path d="M7 13l5-6 5 6"/><path d="M12 11v8"/></svg></span>
               <span class="title">Перепрошивка иммобилайзера</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="alarm-repair" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 11V7a8 8 0 0 1 16 0v4"/><path d="M7 14h10"/><path d="M7 18h10"/></svg></span>
               <span class="title">Ремонт сигнализации</span>
               <span class="hint">Автоэлектрик</span>
             </label>
-            <label class="service-card">
+            <label class="tm-service-card">
               <input type="radio" name="service" value="mobile-autoservice" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M5 11h11l3 3v5H5z"/><path d="M9 11V7h7v4"/><circle cx="8" cy="19" r="2"/><circle cx="18" cy="19" r="2"/></svg></span>
               <span class="title">Автосервис на выезд</span>
@@ -775,17 +775,17 @@ const HERO_FRAMES = [
 
 /* Сетка услуг (иконки-карточки) */
 .tm-service-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}
-.service-card{display:grid;grid-template-columns:auto 1fr;grid-auto-rows:auto;gap:4px 10px;align-items:center;padding:8px 12px;border:1px solid rgba(255,255,255,.1);border-radius:12px;background:rgba(20,24,28,.5);cursor:pointer;transition:transform var(--t), border-color var(--t), background var(--t);min-height:72px}
-.service-card input{display:none}
-.service-card .icon{grid-row:1/span 2;width:34px;height:34px;border-radius:50%;display:grid;place-items:center;border:1.5px solid var(--yellow);background:rgba(255,197,44,.08);color:var(--yellow);}
-.service-card .icon--electric{border-color:#4ec8ff;background:rgba(78,200,255,.08);color:#4ec8ff}
-.service-card .icon--tire{border-color:var(--yellow);background:rgba(255,197,44,.08);color:var(--yellow)}
-.service-card svg{width:18px;height:18px}
-.service-card svg *{fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
-.service-card .title{font-weight:700;font-size:14px;line-height:1.25}
-.service-card .hint{grid-column:2;font-size:11px;color:var(--muted)}
-.service-card:has(input:checked){border-color:var(--yellow);background:rgba(255,197,44,.08)}
-.service-card:hover{transform:translateY(-1px)}
+.tm-service-card{display:grid;grid-template-columns:auto 1fr;grid-auto-rows:auto;gap:4px 10px;align-items:center;padding:8px 12px;border:1px solid rgba(255,255,255,.1);border-radius:12px;background:rgba(20,24,28,.5);cursor:pointer;transition:transform var(--t), border-color var(--t), background var(--t);min-height:72px}
+.tm-service-card input{display:none}
+.tm-service-card .icon{grid-row:1/span 2;width:34px;height:34px;border-radius:50%;display:grid;place-items:center;border:1.5px solid var(--yellow);background:rgba(255,197,44,.08);color:var(--yellow);}
+.tm-service-card .icon--electric{border-color:#4ec8ff;background:rgba(78,200,255,.08);color:#4ec8ff}
+.tm-service-card .icon--tire{border-color:var(--yellow);background:rgba(255,197,44,.08);color:var(--yellow)}
+.tm-service-card svg{width:18px;height:18px}
+.tm-service-card svg *{fill:none;stroke:currentColor;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round}
+.tm-service-card .title{font-weight:700;font-size:14px;line-height:1.25}
+.tm-service-card .hint{grid-column:2;font-size:11px;color:var(--muted)}
+.tm-service-card:has(input:checked){border-color:var(--yellow);background:rgba(255,197,44,.08)}
+.tm-service-card:hover{transform:translateY(-1px)}
 
 /* Двухколоночные поля */
 .row-2{display:grid;grid-template-columns:1fr 1fr;gap:10px}


### PR DESCRIPTION
## Summary
- introduce a dedicated tm-service-card class for calculator options
- update calculator styles to avoid conflicts with the services section grid

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f298fe124832f9567053492618d86)