### PR TITLE
Update services section to focus on tire offerings

### DIFF
--- a/index.html
+++ b/index.html
@@ -2468,22 +2468,21 @@ const HERO_FRAMES = [
     <div class="container">
       <div class="section-head">
         <div class="eyebrow">Наши услуги</div>
-        <h2 class="title" id="services-title">Выездной шиномонтаж и автоэлектрик 24/7</h2>
+        <h2 class="title" id="services-title">Услуги выездного шиномонтажа</h2>
         <p class="subtitle">Полный спектр мобильных работ по СПб и ЛО — приезжаем в среднем за 25 минут.</p>
       </div>
 
       <div class="grid" aria-label="Каталог услуг">
         <article class="service-card">
           <div class="media">
-            <img src="https://images.unsplash.com/photo-1592853625513-e1641f83e1df?q=80&w=2070&auto=format&fit=crop" alt="Ремонт проколов на месте" loading="lazy" width="1280" height="720" />
+            <img src="https://images.unsplash.com/photo-1588572146666-9b7bd8cb8a71?q=80&w=1920&auto=format&fit=crop" alt="Ремонт проколотой шины на выезде" loading="lazy" width="1280" height="720" />
           </div>
           <div class="body">
             <h3>Ремонт проколов</h3>
-            <p>Быстро устраним прокол прямо на месте, без снятия колеса.</p>
+            <p>Прокол колеса — не повод тратить время на поиск сервиса. Мастер TireMasters приедет к вам за 20–30 минут и восстановит шину прямо на месте. Мы используем профессиональные инструменты и надежные жгуты, которые гарантируют герметичность. Вам не нужно искать домкрат или запаску — всё привезём с собой. Быстро, аккуратно и с гарантией безопасности на дороге.</p>
           </div>
           <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
             <ul class="utils" aria-label="Быстрые детали">
               <li class="badge">24/7</li>
               <li class="badge">СПб/ЛО</li>
@@ -2494,15 +2493,14 @@ const HERO_FRAMES = [
 
         <article class="service-card">
           <div class="media">
-            <img src="https://images.unsplash.com/photo-1542362567-b07e54358753?q=80&w=2070&auto=format&fit=crop" alt="Ремонт боковых порезов шины" loading="lazy" width="1280" height="720" />
+            <img src="https://images.unsplash.com/photo-1604668915840-0d1cf594e3c2?q=80&w=1920&auto=format&fit=crop" alt="Ремонт бокового пореза шины" loading="lazy" width="1280" height="720" />
           </div>
           <div class="body">
             <h3>Ремонт боковых порезов</h3>
-            <p>Восстановим целостность боковой части шины с гарантией герметичности.</p>
+            <p>Боковой порез шины — серьёзная проблема, но в большинстве случаев её можно устранить на месте. Наш специалист проведёт диагностику и аккуратно восстановит повреждение специальной технологией усиленной вулканизации. Это сэкономит вам деньги на покупке новой покрышки. Работа выполняется быстро и качественно, без снятия колеса с автомобиля. После ремонта вы сможете спокойно продолжить движение.</p>
           </div>
           <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
             <ul class="utils" aria-label="Быстрые детали">
               <li class="badge">24/7</li>
               <li class="badge">СПб/ЛО</li>
@@ -2513,15 +2511,14 @@ const HERO_FRAMES = [
 
         <article class="service-card">
           <div class="media">
-            <img src="https://images.unsplash.com/photo-1588888801209-c1a3471b1af2?q=80&w=2090&auto=format&fit=crop" alt="Ремонт грыж на колесе" loading="lazy" width="1280" height="720" />
+            <img src="https://images.unsplash.com/photo-1540411025311-95a84aeae09c?q=80&w=1920&auto=format&fit=crop" alt="Восстановление шины с грыжей" loading="lazy" width="1280" height="720" />
           </div>
           <div class="body">
             <h3>Ремонт грыж</h3>
-            <p>Исправим выпуклости и деформации покрышки на выезде.</p>
+            <p>Если на шине появилась грыжа — не рискуйте безопасностью. Мы выезжаем в любое место Санкт-Петербурга и Ленобласти, чтобы помочь вам прямо на дороге. Мастер оценит повреждение и выполнит локальный ремонт с использованием армирующих материалов. Это восстановит прочность шины и продлит срок её службы. Вы избежите дорогостоящей замены и просто продолжите путь.</p>
           </div>
           <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
             <ul class="utils" aria-label="Быстрые детали">
               <li class="badge">24/7</li>
               <li class="badge">СПб/ЛО</li>
@@ -2532,15 +2529,14 @@ const HERO_FRAMES = [
 
         <article class="service-card">
           <div class="media">
-            <img src="https://images.unsplash.com/photo-1613686723137-bb4389f42b08?q=80&w=2069&auto=format&fit=crop" alt="Установка запасного колеса" loading="lazy" width="1280" height="720" />
+            <img src="https://images.unsplash.com/photo-1503377984216-1112bd1cc897?q=80&w=1920&auto=format&fit=crop" alt="Установка запасного колеса мастером" loading="lazy" width="1280" height="720" />
           </div>
           <div class="body">
             <h3>Установка запаски</h3>
-            <p>Поможем установить запасное колесо в экстренной ситуации.</p>
+            <p>Если колесо спущено или повреждено, не мучайтесь сами. Наш специалист приедет и быстро установит запаску, даже если вы на трассе или во дворе. Мы бережно поднимем авто, снимем повреждённое колесо и надёжно закрепим запасное. Всё займёт не больше 20 минут. Без усилий, без грязи и без риска повредить авто.</p>
           </div>
           <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
             <ul class="utils" aria-label="Быстрые детали">
               <li class="badge">24/7</li>
               <li class="badge">СПб/ЛО</li>
@@ -2551,15 +2547,14 @@ const HERO_FRAMES = [
 
         <article class="service-card">
           <div class="media">
-            <img src="https://images.unsplash.com/photo-1531390980331-c32a6ac4ad67?q=80&w=2070&auto=format&fit=crop" alt="Замена комплекта шин" loading="lazy" width="1280" height="720" />
+            <img src="https://images.unsplash.com/photo-1491557345352-5929e343eb89?q=80&w=1920&auto=format&fit=crop" alt="Выездная замена комплекта шин" loading="lazy" width="1280" height="720" />
           </div>
           <div class="body">
             <h3>Замена резины</h3>
-            <p>Проведем полную замену комплекта шин с балансировкой.</p>
+            <p>Пора сменить зимнюю или летнюю резину? Мы сделаем это прямо у вашего дома или офиса. Профессиональное оборудование на выезде позволяет проводить замену так же качественно, как в стационарном шиномонтаже. Мастер проверит давление, балансировку и состояние покрышек. Удобно, быстро и без потери времени.</p>
           </div>
           <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
             <ul class="utils" aria-label="Быстрые детали">
               <li class="badge">24/7</li>
               <li class="badge">СПб/ЛО</li>
@@ -2570,15 +2565,14 @@ const HERO_FRAMES = [
 
         <article class="service-card">
           <div class="media">
-            <img src="https://images.unsplash.com/photo-1588888801209-c1a3471b1af2?q=80&w=2090&auto=format&fit=crop" alt="Дошиповка шин" loading="lazy" width="1280" height="720" />
+            <img src="https://images.unsplash.com/photo-1521590832167-7bcbfaa6381f?q=80&w=1920&auto=format&fit=crop" alt="Дошиповка зимней шины" loading="lazy" width="1280" height="720" />
           </div>
           <div class="body">
             <h3>Дошиповка шин</h3>
-            <p>Вернем сцепление, восстановив утраченные шипы.</p>
+            <p>Потеряли часть шипов? Мы вернём шинам сцепление с дорогой. Наши мастера выполняют дошиповку прямо на месте — без необходимости ехать в сервис. Используются качественные шипы, соответствующие стандарту производителя. После процедуры шина снова будет вести себя уверенно на льду и снегу. Безопасность и уверенность на зимней дороге возвращаются за считанные минуты.</p>
           </div>
           <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
             <ul class="utils" aria-label="Быстрые детали">
               <li class="badge">24/7</li>
               <li class="badge">СПб/ЛО</li>
@@ -2589,15 +2583,14 @@ const HERO_FRAMES = [
 
         <article class="service-card">
           <div class="media">
-            <img src="https://images.unsplash.com/photo-1542362567-b07e54358753?q=80&w=2070&auto=format&fit=crop" alt="Правка дисков" loading="lazy" width="1280" height="720" />
+            <img src="https://images.unsplash.com/photo-1578075054934-1044e94a6a28?q=80&w=1920&auto=format&fit=crop" alt="Правка автомобильного диска" loading="lazy" width="1280" height="720" />
           </div>
           <div class="body">
             <h3>Правка дисков</h3>
-            <p>Выровняем деформации дисков без потери геометрии.</p>
+            <p>Неровности дороги, ямы и бордюры могут погнуть диск. Мы приедем и аккуратно исправим деформацию без снятия с машины, если это возможно. Используем профессиональное оборудование и контроль геометрии. После правки колесо снова вращается идеально ровно, без вибраций и биений. Экономия времени и бюджета по сравнению с покупкой нового диска.</p>
           </div>
           <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
             <ul class="utils" aria-label="Быстрые детали">
               <li class="badge">24/7</li>
               <li class="badge">СПб/ЛО</li>
@@ -2608,15 +2601,14 @@ const HERO_FRAMES = [
 
         <article class="service-card">
           <div class="media">
-            <img src="https://images.unsplash.com/photo-1531390980331-c32a6ac4ad67?q=80&w=2070&auto=format&fit=crop" alt="Хранение шин на складе" loading="lazy" width="1280" height="720" />
+            <img src="https://images.unsplash.com/photo-1462396881884-de2c07cb95ed?q=80&w=1920&auto=format&fit=crop" alt="Сезонное хранение комплекта шин" loading="lazy" width="1280" height="720" />
           </div>
           <div class="body">
             <h3>Хранение шин</h3>
-            <p>Надежное хранение ваших шин в сезон.</p>
+            <p>Нет места для хранения комплекта резины? Мы предлагаем удобный сезонный сервис хранения шин. Забираем колеса прямо от вас, храним в сухом, проветриваемом складе с нужной температурой. Весной или осенью просто вызывайте нас — и мы вернём комплект обратно. Это удобно, безопасно и освобождает место дома.</p>
           </div>
           <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
             <ul class="utils" aria-label="Быстрые детали">
               <li class="badge">24/7</li>
               <li class="badge">СПб/ЛО</li>
@@ -2627,319 +2619,14 @@ const HERO_FRAMES = [
 
         <article class="service-card">
           <div class="media">
-            <img src="https://images.unsplash.com/photo-1592853625513-e1641f83e1df?q=80&w=2070&auto=format&fit=crop" alt="Снятие секреток" loading="lazy" width="1280" height="720" />
+            <img src="https://images.unsplash.com/photo-1503736334956-4c8f8e92946d?q=80&w=1920&auto=format&fit=crop" alt="Снятие секретных гаек с колеса" loading="lazy" width="1280" height="720" />
           </div>
           <div class="body">
             <h3>Снятие секреток</h3>
-            <p>Снимем любые секретки без повреждения дисков.</p>
+            <p>Потеряли ключ от секреток или он сломался? Не беда — мы приедем и аккуратно снимем секретные гайки без повреждения дисков. Работа выполняется с использованием профессиональных инструментов. Восстановим доступ к колесу быстро и без риска для крепежей. Это безопаснее и надёжнее, чем пытаться открутить самому.</p>
           </div>
           <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1517148815978-75f6acaaf32c?q=80&w=2070&auto=format&fit=crop" alt="Компьютерная диагностика автомобиля" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Компьютерная диагностика</h3>
-            <p>Определим неисправности с помощью профессионального оборудования.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1519641471654-76ce0107ad1b?q=80&w=2070&auto=format&fit=crop" alt="Запуск двигателя от внешнего источника" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Запуск двигателя</h3>
-            <p>Запустим автомобиль при севшем аккумуляторе.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1549921296-3b4a6b9b3cfa?q=80&w=2070&auto=format&fit=crop" alt="Диагностика двигателя" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Диагностика двигателя</h3>
-            <p>Проверим систему зажигания, датчики и блок управления.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1517148815978-75f6acaaf32c?q=80&w=2070&auto=format&fit=crop" alt="Замена аккумулятора" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Замена аккумулятора</h3>
-            <p>Быстрая установка нового аккумулятора с проверкой зарядки.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?q=80&w=2070&auto=format&fit=crop" alt="Автоэлектрик для грузового транспорта" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Грузовой автоэлектрик</h3>
-            <p>Электроработы для грузовых и спецавтомобилей.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1519641471654-76ce0107ad1b?q=80&w=2070&auto=format&fit=crop" alt="Прикуривание автомобиля" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Прикурить автомобиль</h3>
-            <p>Поможем завести авто при разряженном аккумуляторе.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1517148815978-75f6acaaf32c?q=80&w=2070&auto=format&fit=crop" alt="Коррекция пробега" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Скрутить пробег</h3>
-            <p>Корректировка показаний одометра при необходимости.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?q=80&w=2070&auto=format&fit=crop" alt="Отключение сигнализации" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Отключение сигнализации</h3>
-            <p>Разблокировка автомобиля при неисправной сигнализации.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1517048676732-d65bc937f952?q=80&w=2070&auto=format&fit=crop" alt="Изготовление ключей" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Изготовление ключей</h3>
-            <p>Изготовим или восстановим ключ прямо на месте.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1517148815978-75f6acaaf32c?q=80&w=2070&auto=format&fit=crop" alt="Ремонт проводки" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Ремонт проводки</h3>
-            <p>Устраним обрывы, короткие замыкания и восстановим электросеть.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1549921296-3b4a6b9b3cfa?q=80&w=2070&auto=format&fit=crop" alt="Ремонт генератора" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Ремонт генераторов</h3>
-            <p>Починим генератор, заменим щетки и регуляторы.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1517048676732-d65bc937f952?q=80&w=2070&auto=format&fit=crop" alt="Ремонт стартера" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Ремонт стартеров</h3>
-            <p>Отремонтируем стартер, проверим тяговое реле.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?q=80&w=2070&auto=format&fit=crop" alt="Отключение иммобилайзера" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Отключение иммобилайзера</h3>
-            <p>Снимем блокировку, если иммобилайзер мешает запуску.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1517148815978-75f6acaaf32c?q=80&w=2070&auto=format&fit=crop" alt="Перепрошивка иммобилайзера" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Перепрошивка иммобилайзера</h3>
-            <p>Обновим или заменим программное обеспечение иммобилайзера.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1519641471654-76ce0107ad1b?q=80&w=2070&auto=format&fit=crop" alt="Ремонт сигнализации" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Ремонт сигнализации</h3>
-            <p>Починим, заменим блоки или настроим систему сигнализации.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
-            <ul class="utils" aria-label="Быстрые детали">
-              <li class="badge">24/7</li>
-              <li class="badge">СПб/ЛО</li>
-              <li class="badge">~25 мин</li>
-            </ul>
-          </div>
-        </article>
-
-        <article class="service-card">
-          <div class="media">
-            <img src="https://images.unsplash.com/photo-1489515217757-5fd1be406fef?q=80&w=2070&auto=format&fit=crop" alt="Автосервис на выезд" loading="lazy" width="1280" height="720" />
-          </div>
-          <div class="body">
-            <h3>Автосервис на выезд</h3>
-            <p>Полный комплекс автоэлектрических услуг с выездом к клиенту.</p>
-          </div>
-          <div class="actions">
-            <a class="btn primary" href="#calc">Рассчитать</a>
-            <a class="btn ghost" href="#price">Прайс</a>
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
             <ul class="utils" aria-label="Быстрые детали">
               <li class="badge">24/7</li>
               <li class="badge">СПб/ЛО</li>
@@ -4317,7 +4004,6 @@ Assumptions (разумные допущения):
             Telegram
           </a>
         </div>
-      </div>
     </div>
 
     <div class="reviews__cta">
@@ -5043,7 +4729,6 @@ document.addEventListener("DOMContentLoaded", () => {
           <a class="tm-sub__link focusable" href="#policy">Политика конфиденциальности</a>
           <a class="tm-sub__link focusable" href="#offer">Публичная оферта</a>
         </div>
-      </div>
     </div>
 
     <div class="tm-footer__tread" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- rename the services section heading to «Услуги выездного шиномонтажа»
- replace the catalog with nine targeted шиномонтаж cards and add detailed marketing copy for each
- swap the double CTA buttons for a single «Вызвать шиномонтаж» action across the grid

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911788db240832f833b63ab80e60307)