### PR TITLE
Update calculator flow to remove pricing estimate and highlight contact CTAs

### DIFF
--- a/index.html
+++ b/index.html
@@ -684,65 +684,34 @@ const HERO_FRAMES = [
           <label class="radio"><input type="radio" name="contact" value="call" checked> Позвоните</label>
           <label class="radio"><input type="radio" name="contact" value="messenger"> Напишите (WA/TG)</label>
         </fieldset>
-
-        <!-- Итог / Диапазон -->
-        <div class="tm-total" aria-live="polite">
-          <div class="price"><span id="totalFrom">—</span> – <span id="totalTo">—</span> ₽</div>
-          <div class="note">Ориентир. Точную стоимость и ETA подтвердим по телефону.</div>
-        </div>
-
         <!-- CTA -->
         <div class="tm-actions">
-          <button type="button" class="btn btn-primary-outline" id="btnCalc">Рассчитать цену</button>
           <button type="submit" class="btn btn-secondary" id="btnOrder">Вызвать мастера</button>
         </div>
 
         <div class="tm-alert" id="formAlert" role="alert" hidden></div>
       </form>
-    </div>
 
-    <!-- Правая колонка: подсказки/бейджи -->
-    <aside class="tm-calc__right" aria-label="Подсказки и условия">
-      <ul class="tm-badges">
-        <li class="badge">
-          <span class="b-ico"><svg viewBox="0 0 24 24" aria-hidden="true"><circle cx="12" cy="12" r="9"></circle><path d="M12 7v6l4 2"/></svg></span>
-          <div><div class="b-title">~25 мин</div><div class="b-sub">Средний ETA по СПб</div></div>
-        </li>
-        <li class="badge">
-          <span class="b-ico"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 3 5 6v6c0 4.28 2.94 7.58 7 9 4.06-1.42 7-4.72 7-9V6l-7-3Z"/></svg></span>
-          <div><div class="b-title">30 дней</div><div class="b-sub">Гарантия на работы</div></div>
-        </li>
-        <li class="badge">
-          <span class="b-ico"><svg viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><rect x="3" y="9" width="18" height="2"/></svg></span>
-          <div><div class="b-title">Оплата картой</div><div class="b-sub">На месте, онлайн</div></div>
-        </li>
-        <li class="badge">
-          <span class="b-ico"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12h18M12 3v18"/></svg></span>
-          <div><div class="b-title">RunFlat +20%</div><div class="b-sub">SUV +15%, Ночь +20%</div></div>
-        </li>
-      </ul>
-
-      <!-- TM-MARK: CTA В ПРАВОЙ КОЛОНКЕ START -->
-      <div class="tm-cta-corner" role="region" aria-label="Быстрые действия (в правой колонке)">
-    <a class="cta-btn cta-primary" href="tel:+79531580900" aria-label="Позвонить в TireMasters">
-      <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.11 4.2 2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.72c.12.9.3 1.78.57 2.63a2 2 0 0 1-.45 2.11L8.1 9.1a16 16 0 0 0 6 6l.64-1.12a2 2 0 0 1 2.11-.45c.85.27 1.73.45 2.63.57A2 2 0 0 1 22 16.92z"/></svg></span>
-      <span class="txt"><strong>Позвонить</strong><em>+7 953 158 0900</em></span>
-    </a>
-    <a class="cta-btn cta-accent" href="#calc" aria-label="Вызвать шиномонтаж — перейти к форме">
-      <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M7 12h10M12 7v10"/></svg></span>
-      <span class="txt"><strong>Вызвать шиномонтаж</strong><em>оформить заявку</em></span>
-    </a>
-    <a class="cta-btn" href="https://t.me/Tiar_MASTERSPro" target="_blank" rel="noopener" aria-label="Написать в Telegram">
-      <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M21.44 3.2 2.35 10.63c-.86.35-.86 1.64.1 1.97l4.86 1.6 1.87 6.07c.24.78 1.22.86 1.66.14l2.67-4.33 4.9 3.66c.77.57 1.86.14 2.06-.82l-.34-14.1Z"/></svg></span>
-      <span class="txt"><strong>Telegram</strong><em>@Tiar_MASTERSPro</em></span>
-    </a>
-    <a class="cta-btn" href="https://wa.me/79531580900" target="_blank" rel="noopener" aria-label="Написать в WhatsApp">
-      <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M17.47 14.33c-.28-.14-1.66-.8-1.92-.9-.26-.1-.46-.14-.66.14-.2.28-.76.9-.94 1.08-.18.18-.34.2-.62.06-.28-.14-1.16-.43-2.2-1.38-.81-.72-1.36-1.6-1.52-1.88-.16-.28-.02-.44.12-.58.12-.12.28-.32.42-.48.14-.16.18-.28.28-.46.1-.18.06-.34-.02-.48-.08-.14-.66-1.58-.9-2.16-.24-.58-.48-.5-.66-.5-.18 0-.38-.02-.58-.02s-.54.08-.82.38c-.28.3-1.08 1.06-1.08 2.58 0 1.52 1.1 2.98 1.26 3.18.16.2 2.16 3.3 5.22 4.54.73.3 1.3.48 1.74.62.73.24 1.38.2 1.9.12.58-.08 1.78-.72 2.04-1.42.26-.7.26-1.3.2-1.42-.06-.12-.54-1.3-.74-1.78-.2-.48-.4-.42-.58-.42Z"/></svg></span>
-      <span class="txt"><strong>WhatsApp</strong><em>написать</em></span>
-    </a>
+      <div class="tm-cta-corner" role="region" aria-label="Способы связи">
+        <a class="cta-btn cta-primary" href="tel:+79531580900" aria-label="Позвонить в TireMasters">
+          <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6A19.79 19.79 0 0 1 2.11 4.2 2 2 0 0 1 4.1 2h3a2 2 0 0 1 2 1.72c.12.9.3 1.78.57 2.63a2 2 0 0 1-.45 2.11L8.1 9.1a16 16 0 0 0 6 6l.64-1.12a2 2 0 0 1 2.11-.45c.85.27 1.73.45 2.63.57A2 2 0 0 1 22 16.92z"/></svg></span>
+          <span class="txt"><strong>Позвонить</strong><em>+7 953 158 0900</em></span>
+        </a>
+        <a class="cta-btn cta-accent" href="#calc" aria-label="Вызвать шиномонтаж — перейти к форме">
+          <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M7 12h10M12 7v10"/></svg></span>
+          <span class="txt"><strong>Вызвать шиномонтаж</strong><em>оформить заявку</em></span>
+        </a>
+        <a class="cta-btn" href="https://t.me/Tiar_MASTERSPro" target="_blank" rel="noopener" aria-label="Написать в Telegram">
+          <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M21.44 3.2 2.35 10.63c-.86.35-.86 1.64.1 1.97l4.86 1.6 1.87 6.07c.24.78 1.22.86 1.66.14l2.67-4.33 4.9 3.66c.77.57 1.86.14 2.06-.82l-.34-14.1Z"/></svg></span>
+          <span class="txt"><strong>Telegram</strong><em>@Tiar_MASTERSPro</em></span>
+        </a>
+        <a class="cta-btn" href="https://wa.me/79531580900" target="_blank" rel="noopener" aria-label="Написать в WhatsApp">
+          <span class="ico" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M17.47 14.33c-.28-.14-1.66-.8-1.92-.9-.26-.1-.46-.14-.66.14-.2.28-.76.9-.94 1.08-.18.18-.34.2-.62.06-.28-.14-1.16-.43-2.2-1.38-.81-.72-1.36-1.6-1.52-1.88-.16-.28-.02-.44.12-.58.12-.12.28-.32.42-.48.14-.16.18-.28.28-.46.1-.18.06-.34-.02-.48-.08-.14-.66-1.58-.9-2.16-.24-.58-.48-.5-.66-.5-.18 0-.38-.02-.58-.02s-.54.08-.82.38c-.28.3-1.08 1.06-1.08 2.58 0 1.52 1.1 2.98 1.26 3.18.16.2 2.16 3.3 5.22 4.54.73.3 1.3.48 1.74.62.73.24 1.38.2 1.9.12.58-.08 1.78-.72 2.04-1.42.26-.7.26-1.3.2-1.42-.06-.12-.54-1.3-.74-1.78-.2-.48-.4-.42-.58-.42Z"/></svg></span>
+          <span class="txt"><strong>WhatsApp</strong><em>написать</em></span>
+        </a>
       </div>
-      <!-- TM-MARK: CTA В ПРАВОЙ КОЛОНКЕ END -->
-    </aside>
+
+    </div>
   </div>
   <!-- TM-MARK: HTML END -->
 
@@ -762,8 +731,8 @@ const HERO_FRAMES = [
 .tm-calc__bg{background-image:var(--calc-bg-url)}
 .tm-calc__mask{position:absolute;inset:0;background:linear-gradient(135deg, rgba(10,12,14,.72) 0%, rgba(10,12,14,.58) 40%, rgba(10,12,14,.42) 100%)}
 
-/* Контейнер и сетка 2/3 — 1/3, на всю ширину до 1280px */
-.tm-calc__container{width:var(--container);margin-inline:auto;display:grid;grid-template-columns:2fr 1fr;gap:28px;align-items:start}
+/* Контейнер: единая колонка на всю ширину до 1280px */
+.tm-calc__container{width:var(--container);margin-inline:auto;display:flex;flex-direction:column;gap:24px;align-items:stretch}
 
 .tm-calc__title{margin:0 0 6px;font-size:clamp(22px,2.8vw,36px);font-weight:800}
 .tm-calc__subtitle{margin:0 0 14px;color:var(--muted)}
@@ -809,10 +778,6 @@ const HERO_FRAMES = [
 .chk{display:inline-flex;gap:8px;align-items:center;background:rgba(255,255,255,.03);border:1px solid rgba(255,255,255,.1);padding:8px 10px;border-radius:10px}
 .tm-coefs .km{width:120px}
 
-/* Итог */
-.tm-total{display:flex;justify-content:space-between;align-items:last baseline;background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.1);border-radius:12px;padding:12px;margin:12px 0}
-.tm-total .price{font-size:clamp(18px,2.2vw,26px);font-weight:800}
-.tm-total .note{font-size:12px;color:var(--muted);max-width:60ch}
 
 /* Кнопки */
 .btn{display:inline-flex;align-items:center;gap:10px;padding:12px 16px;border-radius:12px;text-decoration:none;transition:all var(--t) ease;box-shadow:var(--shadow);cursor:pointer}
@@ -822,13 +787,6 @@ const HERO_FRAMES = [
 .btn-secondary:hover,.btn-secondary:focus{background:#1a1f27}
 .tm-actions{display:flex;flex-wrap:wrap;gap:10px}
 
-/* Подсказки справа (бейджи в стиле Hero) */
-.tm-badges{display:grid;gap:12px;list-style:none;margin:0;padding:0}
-.badge{display:grid;grid-template-columns:auto 1fr;gap:10px;align-items:center;background:rgba(20,24,28,.6);border:1px solid rgba(255,255,255,.08);border-radius:14px;padding:12px 14px;backdrop-filter:blur(4px)}
-.b-ico{width:38px;height:38px;border-radius:50%;display:grid;place-items:center;border:2px solid var(--red)}
-.b-ico svg{width:20px;height:20px;stroke:var(--steel);stroke-width:2;fill:none}
-.b-title{font-weight:800}
-.b-sub{font-size:12px;color:var(--muted)}
 
 /* Ошибки и алерты */
 .err{color:#ff8b8b;font-size:12px;margin:4px 0 0}
@@ -838,20 +796,16 @@ const HERO_FRAMES = [
 .tm-alert.error{border-color:rgba(255,69,69,.5);background:rgba(255,69,69,.07);color:#ffb0b0}
 
 /* Анимации появления (FadeUp как в Hero) */
-.tm-calc__left,.tm-calc__right{opacity:0;transform:translateY(10px)}
+.tm-calc__left{opacity:0;transform:translateY(10px)}
 .tm-calc.is-mounted .tm-calc__left{animation:fadeUp var(--t) ease forwards 80ms}
-.tm-calc.is-mounted .tm-calc__right{animation:fadeUp var(--t) ease forwards 160ms}
+
 @keyframes fadeUp{to{opacity:1;transform:translateY(0)}}
 
 /* Респонсив */
-@media (max-width: 1024px){
-  .tm-calc__container{grid-template-columns:1fr}
-}
 
 @media (max-width: 720px){
   .tm-service-grid{grid-template-columns:repeat(2,minmax(0,1fr))}
   .row-2{grid-template-columns:1fr}
-  .tm-total{flex-direction:column;gap:6px}
   .tm-input--control{--control-height:60px;}
   .tm-input--control input,
   .tm-input--control select{min-height:var(--control-height);padding:16px 56px 16px 14px;font-size:15px;}
@@ -860,12 +814,6 @@ const HERO_FRAMES = [
   .tm-input--control .ico{top:calc(100% - (var(--control-height)/2));transform:translateY(-50%);}
   .tm-input--control .geo-btn{top:calc(100% - (var(--control-height)/2));width:44px;height:44px;right:12px;transform:translateY(-50%);}
 }
-
-  /* TM-MARK: ВЫРАВНИВАНИЕ ПРАВОГО БЛОКА START */
-  .tm-calc__right{display:grid; justify-items:center; align-content:start; gap:14px;}
-  .tm-badges{width:100%; max-width:420px; margin-inline:auto;}
-  .tm-cta-corner{max-width:420px;}
-  /* TM-MARK: ВЫРАВНИВАНИЕ ПРАВОГО БЛОКА END */
   </style>
   <!-- TM-MARK: CSS END -->
 
@@ -878,14 +826,10 @@ const HERO_FRAMES = [
 
 /* Общие стили CTA */
 .tm-cta-corner{
-  position:absolute;
-  right:22px;
-  bottom:22px;
+  margin-top:24px;
   display:grid;
-  grid-template-columns:1fr;
-  gap:10px;
-  max-width:min(36vw, 420px);
-  z-index:5;
+  gap:12px;
+  grid-template-columns:repeat(auto-fit, minmax(220px, 1fr));
 }
 
 .cta-btn{
@@ -954,35 +898,15 @@ const HERO_FRAMES = [
   border:2px solid #FF4545;
 }
 
-/* ✅ Исправленное выравнивание CTA в правом блоке калькулятора */
-.tm-calc__right .tm-cta-corner{
-  position:relative;
-  right:0;
-  bottom:0;
-  width:100%;
-  margin-top:10px;
-  display:grid;
-  gap:10px;
-}
-.tm-calc__right .tm-cta-corner .cta-btn{
-  width:100%;
-  border-radius:14px;
-  min-height:86px;
-}
-
 /* Адаптив */
 @media (max-width:1024px){
   .tm-cta-corner{
-    right:14px;
-    bottom:14px;
-    max-width:min(50vw,380px);
+    grid-template-columns:repeat(auto-fit, minmax(200px, 1fr));
   }
 }
 @media (max-width:720px){
   .tm-cta-corner{
-    position:static;
-    margin-top:12px;
-    max-width:none;
+    grid-template-columns:1fr;
   }
 }
 </style>
@@ -997,81 +921,23 @@ const HERO_FRAMES = [
   requestAnimationFrame(()=> root.classList.add('is-mounted'));
 
   const form = root.querySelector('#calcForm');
-  const btnCalc = root.querySelector('#btnCalc');
   const btnOrder = root.querySelector('#btnOrder');
   const alertBox = root.querySelector('#formAlert');
-  const outFrom = root.querySelector('#totalFrom');
-  const outTo = root.querySelector('#totalTo');
 
   const errService = root.querySelector('#err-service');
   const errRadius = root.querySelector('#err-radius');
   const errPhone = root.querySelector('#err-phone');
 
-  const svc = {
-    'repair-puncture': { base:[1200, 1800] },
-    'sidewall-repair': { base:[1600, 2600] },
-    'hernia-repair': { base:[2200, 3200] },
-    'spare-install': { base:[1000, 1500] },
-    'tire-change': { base:[2800, 4200] },
-    'stud-install': { base:[1800, 2600] },
-    'rim-straightening': { base:[2500, 3800] },
-    'tire-storage': { base:[1900, 2600] },
-    'lock-removal': { base:[1300, 2000] },
-    'computer-diagnostics': { base:[2500, 3800] },
-    'engine-start': { base:[1500, 2200] },
-    'engine-diagnostics': { base:[3200, 4800] },
-    'battery-replacement': { base:[2200, 3600] },
-    'truck-electric': { base:[4200, 6200] },
-    'jump-start': { base:[1600, 2300] },
-    'odometer-correction': { base:[4500, 7000] },
-    'alarm-disable': { base:[2800, 4200] },
-    'key-making': { base:[3200, 5200] },
-    'wiring-repair': { base:[2600, 4600] },
-    'alternator-repair': { base:[3800, 5600] },
-    'starter-repair': { base:[3200, 5000] },
-    'immobilizer-disable': { base:[3400, 5200] },
-    'immobilizer-flash': { base:[3600, 5400] },
-    'alarm-repair': { base:[2800, 4500] },
-    'mobile-autoservice': { base:[4500, 7200] }
-  };
-
-  function coefTotal(base){
-    const f = new FormData(form);
-    let [min,max] = base;
-    if(f.get('suv') === 'on' || f.get('cartype')==='suv') { min*=1.15; max*=1.15; }
-    if(f.get('runflat')==='on') { min*=1.20; max*=1.20; }
-    const hour = new Date().getHours();
-    const isNightNow = (hour >= 22 || hour < 8);
-    if(f.get('night')==='on' || isNightNow) { min*=1.20; max*=1.20; }
-    const km = parseInt(f.get('zkad')||'0',10);
-    if(!isNaN(km) && km>0){ min += 35*km; max += 35*km; }
-    const radius = (f.get('radius')||'R16').replace('R','')*1;
-    if(radius>=19){ min*=1.10; max*=1.12; }
-    if(radius>=22){ min*=1.12; max*=1.15; }
-    return [Math.round(min), Math.round(max)];
-  }
-
   function validate(){
     const f = new FormData(form);
-    let ok = true; alertBox.hidden = true;
+    let ok = true;
+    alertBox.hidden = true;
     if(!f.get('service')){ errService.hidden = false; ok = false; } else errService.hidden = true;
     if(!f.get('radius')){ errRadius.hidden = false; ok = false; } else errRadius.hidden = true;
     const phone = (f.get('phone')||'').trim();
     if(!phone){ errPhone.hidden = false; ok = false; } else errPhone.hidden = true;
     return ok;
   }
-
-  function recalc(){
-    if(!validate()) return;
-    const f = new FormData(form);
-    const service = f.get('service');
-    const base = (svc[service]||svc['repair-puncture']).base;
-    const [from, to] = coefTotal(base);
-    outFrom.textContent = from.toLocaleString('ru-RU');
-    outTo.textContent = to.toLocaleString('ru-RU');
-  }
-
-  btnCalc.addEventListener('click', recalc);
 
   form.addEventListener('submit', (e)=>{
     e.preventDefault();
@@ -3059,7 +2925,7 @@ const HERO_FRAMES = [
     }
 
     /* Бейджи/подсказки */
-    .badge{ display:inline-flex; align-items:center; gap:6px; 
+    .badge{ display:inline-flex; align-items:center; gap:6px;
       padding:6px 10px; border-radius:999px; font-size:12px; font-weight:700;
       background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.08);
       color:var(--txt-1);


### PR DESCRIPTION
## Summary
- remove the pricing estimate output and calculate button from the calculator form
- collapse the calculator layout to a single column and show the contact CTA block immediately after the form
- simplify the calculator script to only validate and submit while updating CTA styling for the new layout

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69117c127ccc832f8ea3f30abdfc039f)