### PR TITLE
Switch site typography to Rubik

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>TireMasters — Header</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
     :root {
       --bg-0: #0B0D10;
       --text-0: #E8EAED;
@@ -26,7 +27,7 @@
       margin: 0;
       background: var(--bg-0);
       color: var(--text-0);
-      font-family: Inter, sans-serif;
+      font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;
       padding-top: var(--header-offset);
     }
 
@@ -295,6 +296,7 @@
 
   <!-- TM-MARK: CSS START -->
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
 :root{
   --bg-1: #0B0D10; --bg-2: #121418;
   --white: #EEF1F4; --muted: #A3AFBF;
@@ -486,6 +488,7 @@ const HERO_FRAMES = [
 
   <!-- TM-MARK: CSS START -->
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
     .tm-about {
       position: relative;
       padding: clamp(56px, 8vw, 88px) 0 clamp(60px, 9vw, 96px);
@@ -930,6 +933,7 @@ const HERO_FRAMES = [
 
   <!-- TM-MARK: CSS START -->
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
 :root{
   --bg-1:#0B0D10; --bg-2:#121418; --white:#EEF1F4; --muted:#A3AFBF;
   --steel:#95A2B3; --red:#FF4545; --yellow:#FFC52C; --container:max(72vw, min(92vw, 1280px));
@@ -1032,6 +1036,7 @@ const HERO_FRAMES = [
 
  <!-- TM-MARK: CTA УГОЛ CSS START -->
 <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
 :root{
   --ctaRadius:16px;
   --ctaShadow:0 10px 30px rgba(0,0,0,.35);
@@ -1263,6 +1268,7 @@ const HERO_FRAMES = [
 
   <!-- TM-MARK: CSS START -->
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
   :root {
     --tow-yellow: #FFC52C;
     --tow-muted: #A3AFBF;
@@ -1690,6 +1696,7 @@ const HERO_FRAMES = [
   </div>
 
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
     :root {
       --electrician-bg: linear-gradient(135deg, rgba(11, 13, 16, 0.92), rgba(20, 24, 31, 0.86));
       --electrician-surface: rgba(18, 22, 28, 0.75);
@@ -2315,6 +2322,7 @@ const HERO_FRAMES = [
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Блок услуг</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
     :root {
       /* TM-MARK: SERVICES_BG_VARS START */
       --services-mask-from: rgba(10, 12, 14, .72);
@@ -2841,6 +2849,7 @@ const HERO_FRAMES = [
 <!-- TM-MARK: HOW-IT-WORKS HTML END -->
 
 <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
 /* TM-MARK: HOW-IT-WORKS CSS START */
 :root{
   --bg-0:#0B0D10; --bg-1:#121418; --txt-0:#EEF1F5; --txt-1:#B7C0CC; --glass:#0F1318CC; --stroke:#2A2F36; --focus:#DDE3EA;
@@ -3020,6 +3029,7 @@ Assumptions (разумные допущения):
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ГЕО — Бейджи районов</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
     :root{
       --bg-1: #0B0D10; /* база */
       --glass: rgba(255,255,255,0.04);
@@ -3031,7 +3041,7 @@ Assumptions (разумные допущения):
       --gap: 16px;
       --transition: 180ms cubic-bezier(.2,.8,.2,1);
     }
-    html,body{height:100%;margin:0;background:var(--bg-1);font-family:Inter,ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,"Helvetica Neue",Arial; color:#e6e9eb;-webkit-font-smoothing:antialiased}
+    html,body{height:100%;margin:0;background:var(--bg-1);font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif; color:#e6e9eb;-webkit-font-smoothing:antialiased}
 
     /* Background photo + glass */
     .geo-section{
@@ -3346,6 +3356,7 @@ Assumptions (разумные допущения):
 </section>
 
 <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
 @import url('https://unpkg.com/swiper@10/swiper-bundle.min.css');
 
 .cases-section {color:#fff;padding:80px 0;scroll-margin-top:88px;}
@@ -3427,11 +3438,12 @@ Assumptions (разумные допущения):
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Блок Отзывы</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
     body {
       margin: 0;
       background: linear-gradient(180deg, #0B0D10 0%, #121418 100%);
       color: #D1D5DB;
-      font-family: 'Inter', sans-serif;
+      font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;
     }
 
     section.reviews {
@@ -3762,7 +3774,8 @@ Assumptions (разумные допущения):
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>TireMasters — FAQ (одна колонка)</title>
 <style>
-  body{margin:0;background:#0b0d10;color:#e6eef5;font-family:Inter,ui-sans-serif,system-ui;-webkit-font-smoothing:antialiased;}
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
+  body{margin:0;background:#0b0d10;color:#e6eef5;font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;-webkit-font-smoothing:antialiased;}
   .faq-section{
   padding:48px 16px;
   scroll-margin-top:88px;
@@ -3815,6 +3828,7 @@ document.querySelectorAll('.toggle-btn').forEach(btn=>{
 <div class="tm-section-divider" aria-hidden="true"></div>
 
 <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
 body {
   background-color: #2a2a2a;
   background-image: repeating-linear-gradient(
@@ -3865,6 +3879,7 @@ body {
 </section>
 
 <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
 /* ===== СЕКЦИЯ ===== */
 .promo-section {
   position: relative;
@@ -3898,17 +3913,17 @@ body {
 }
 .promo-card:hover { box-shadow: 0 0 32px rgba(255, 69, 69, 0.3); transform: translateY(-4px); }
 
-.promo-title { font-family: 'Russo One', sans-serif; font-size: 2.5rem; margin-bottom: 24px; text-transform: uppercase; letter-spacing: 1px; color: #ffffff; }
-.promo-subtitle { font-family: 'Inter', sans-serif; font-size: 1.25rem; color: #b6bbc3; margin-bottom: 40px; line-height: 1.6; }
+.promo-title { font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif; font-size: 2.5rem; margin-bottom: 24px; text-transform: uppercase; letter-spacing: 1px; color: #ffffff; }
+.promo-subtitle { font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif; font-size: 1.25rem; color: #b6bbc3; margin-bottom: 40px; line-height: 1.6; }
 
 .promo-metrics { display: flex; justify-content: center; gap: 40px; margin-bottom: 40px; flex-wrap: wrap; }
 .metric-item { text-align: center; }
-.metric-value { display: block; font-family: 'IBM Plex Mono', monospace; font-size: 1.75rem; color: #ffc107; margin-bottom: 4px; }
+.metric-value { display: block; font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif; font-size: 1.75rem; color: #ffc107; margin-bottom: 4px; }
 .metric-label { color: #b6bbc3; font-size: 0.95rem; }
 
-.promo-description { font-family: 'Inter', sans-serif; font-size: 1rem; line-height: 1.7; color: #e8eaed; margin-bottom: 40px; }
+.promo-description { font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif; font-size: 1rem; line-height: 1.7; color: #e8eaed; margin-bottom: 40px; }
 
-.promo-btn { background: #ff4545; border: none; border-radius: 8px; color: #fff; padding: 16px 36px; font-family: 'Inter', sans-serif; font-weight: 600; font-size: 1.1rem; cursor: pointer; transition: all 0.2s ease; }
+.promo-btn { background: #ff4545; border: none; border-radius: 8px; color: #fff; padding: 16px 36px; font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif; font-weight: 600; font-size: 1.1rem; cursor: pointer; transition: all 0.2s ease; }
 .promo-btn:hover { background: #ff5e5e; box-shadow: 0 0 16px rgba(255, 69, 69, 0.5); }
 
 /* ===== МОДАЛ ===== */
@@ -3916,9 +3931,9 @@ body {
 .promo-modal.active { display: flex; }
 .promo-modal-overlay { position: absolute; inset: 0; background: rgba(0,0,0,0.6); backdrop-filter: blur(4px); }
 .promo-modal-content { position: relative; background: #121418; border: 1px solid #ff4545; border-radius: 16px; padding: 32px 24px; text-align: center; z-index: 1001; max-width: 340px; width: 90%; box-shadow: 0 0 24px rgba(255, 69, 69, 0.3); }
-.promo-modal-content h3 { font-family: 'Russo One', sans-serif; color: #ffffff; margin-bottom: 16px; }
-.promo-code { font-family: 'IBM Plex Mono', monospace; font-size: 1.5rem; color: #ff4545; background: rgba(255, 69, 69, 0.1); border-radius: 8px; padding: 12px 16px; margin-bottom: 16px; user-select: all; }
-.copy-btn { background: #ff4545; border: none; border-radius: 6px; color: #fff; padding: 10px 20px; cursor: pointer; font-family: 'Inter', sans-serif; font-weight: 500; transition: 0.2s; }
+.promo-modal-content h3 { font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif; color: #ffffff; margin-bottom: 16px; }
+.promo-code { font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif; font-size: 1.5rem; color: #ff4545; background: rgba(255, 69, 69, 0.1); border-radius: 8px; padding: 12px 16px; margin-bottom: 16px; user-select: all; }
+.copy-btn { background: #ff4545; border: none; border-radius: 6px; color: #fff; padding: 10px 20px; cursor: pointer; font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif; font-weight: 500; transition: 0.2s; }
 .copy-btn:hover { background: #ff5e5e; }
 .promo-note { color: #b6bbc3; font-size: 0.875rem; margin-top: 12px; }
 .promo-modal-close { position: absolute; top: 8px; right: 12px; background: none; border: none; color: #e8eaed; font-size: 1.5rem; cursor: pointer; }
@@ -3999,6 +4014,7 @@ document.addEventListener("DOMContentLoaded", () => {
 </section>
 
 <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
   .contacts-section {
     background-color: #0B0D10;
     color: #E8EAED;
@@ -4027,20 +4043,20 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   .contacts-title {
-    font-family: 'Russo One', sans-serif;
+    font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;
     font-size: 2rem;
     margin-bottom: 12px;
   }
 
   .contacts-subtitle {
-    font-family: 'Inter', sans-serif;
+    font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;
     color: #B6BBC3;
     margin-bottom: 40px;
   }
 
   .contacts-phone a {
     color: #E8EAED;
-    font-family: 'IBM Plex Mono', monospace;
+    font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;
     font-size: 1.2rem;
     text-decoration: none;
     transition: color 0.2s ease;
@@ -4061,7 +4077,7 @@ document.addEventListener("DOMContentLoaded", () => {
     display: inline-block;
     padding: 14px 28px;
     border-radius: 8px;
-    font-family: 'Inter', sans-serif;
+    font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;
     text-decoration: none;
     transition: all 0.25s ease;
     font-weight: 500;
@@ -4104,7 +4120,7 @@ document.addEventListener("DOMContentLoaded", () => {
     padding: 8px 16px;
     border-radius: 30px;
     font-size: 0.9rem;
-    font-family: 'Inter', sans-serif;
+    font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;
   }
 
   .contacts-email a {
@@ -4162,6 +4178,7 @@ document.addEventListener("DOMContentLoaded", () => {
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>TireMasters — Footer Block</title>
   <style>
+    @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
     /* =============================
        TM-MARK: FOOTER CSS START
        ============================= */
@@ -4195,7 +4212,7 @@ document.addEventListener("DOMContentLoaded", () => {
     .tm-footer {
       background: var(--tm-bg-deep);
       color: var(--tm-text-primary);
-      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Helvetica Neue", sans-serif;
+      font-family: 'Rubik', system-ui, -apple-system, 'Segoe UI', sans-serif;
       border-top: 1px solid var(--tm-border);
     }
 


### PR DESCRIPTION
## Summary
- import the Rubik typeface from Google Fonts across the embedded style blocks
- update all font-family declarations to use the new Rubik-based stack sitewide

## Testing
- not run (static site change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125c0fe5ac832fa008ecc8a356256b)