### PR TITLE
Enhance diagonal stripe accents on service surfaces

### DIFF
--- a/index.html
+++ b/index.html
@@ -2327,7 +2327,7 @@ const HERO_FRAMES = [
       /* TM-MARK: SERVICES_BG_VARS START */
       --services-mask-from: rgba(10, 12, 14, .72);
       --services-mask-to: rgba(10, 12, 14, .42);
-      --services-line-color: rgba(185, 36, 40, .32);
+      --services-line-color: rgba(245, 66, 70, .48);
       --services-container-max: 1200px; /* синхронизировано с 120.html */
       --surface-glass: rgba(17, 19, 22, .48);
       --surface-glass-hover: rgba(17, 19, 22, .62);
@@ -2367,8 +2367,8 @@ const HERO_FRAMES = [
       z-index: -2;
       background:
         repeating-linear-gradient(135deg,
-          var(--services-line-color) 0px 3px,
-          transparent 3px 30px);
+          var(--services-line-color) 0px 6px,
+          transparent 6px 28px);
       opacity: .7;
       mix-blend-mode: screen;
       mask-image: linear-gradient(180deg,


### PR DESCRIPTION
## Summary
- increase the diagonal stripe color intensity for tm-surface--services sections
- widen the repeating stripe pattern to make the red slashes more prominent

## Testing
- no automated tests were run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912beebc8b8832fa59e86020a5bfc02)