### PR TITLE
Center geo section buttons on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -3052,6 +3052,18 @@ Assumptions (разумные допущения):
       .geo-section{padding:24px 16px}
       .badges-grid{grid-template-columns:repeat(1, minmax(0,1fr));}
       .geo-header{flex-direction:column;align-items:flex-start}
+      .geo-cta{
+        width:100%;
+        max-width:320px;
+        margin:0 auto;
+        justify-content:center;
+        align-self:center;
+        gap:10px;
+        flex-wrap:nowrap;
+      }
+      .geo-cta .btn{
+        flex:0 0 auto;
+      }
     }
 
     /* Placeholder services list for demonstrating filter behavior */


### PR DESCRIPTION
## Summary
- center the geo-section action buttons within their container on narrow screens
- ensure the pair of buttons stay on one line and share consistent spacing on mobile

## Testing
- Manual visual verification

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915916619ac832f8dad521e9bba4ff6)