### PR TITLE
Fix mobile layout of geography call-to-action buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -3060,9 +3060,13 @@ Assumptions (разумные допущения):
         align-self:center;
         gap:10px;
         flex-wrap:nowrap;
+        flex-direction:column;
+        align-items:stretch;
       }
       .geo-cta .btn{
         flex:0 0 auto;
+        width:100%;
+        justify-content:center;
       }
     }
 


### PR DESCRIPTION
## Summary
- stack the geography section buttons vertically on small screens
- ensure each button expands to full width for clearer tap targets

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691592f1533c832fa7cef6a75edef18f)