### PR TITLE
Fix mobile drawer overflow on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,14 +86,15 @@
 
     /* Drawer */
     .mobile-drawer { position: fixed; top: 0; right: 0; bottom: 0; width: min(85vw,340px); background: #0E1116; transform: translateX(100%);
-      transition: transform var(--anim-mid) ease; z-index: 1500; padding: 16px; display: flex; flex-direction: column; gap: 12px; }
+      transition: transform var(--anim-mid) ease; z-index: 1500; padding: calc(16px + env(safe-area-inset-top, 0)) 16px calc(16px + env(safe-area-inset-bottom, 0)); display: flex;
+      flex-direction: column; gap: 12px; overflow: hidden; }
     .mobile-drawer.open { transform: translateX(0); }
     .mobile-drawer__close { display: inline-flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: auto;
-      border: none; border-radius: 12px; background: rgba(255,255,255,0.08); color: var(--text-0); cursor: pointer; transition: background var(--anim-mid) ease, color var(--anim-mid) ease; }
+      border: none; border-radius: 12px; background: rgba(255,255,255,0.08); color: var(--text-0); cursor: pointer; transition: background var(--anim-mid) ease, color var(--anim-mid) ease; position: sticky; top: 0; right: 0; z-index: 1; }
     .mobile-drawer__close:hover { background: rgba(255,255,255,0.16); color: #fff; }
     .mobile-drawer__close:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--focus); background: rgba(255,255,255,0.16); color: #fff; }
     .mobile-drawer__close svg { pointer-events: none; }
-    .mobile-drawer ul { list-style: none; margin: 20px 0; padding: 0; }
+    .mobile-drawer ul { list-style: none; margin: 20px 0 0; padding: 0; flex: 1 1 auto; overflow-y: auto; min-height: 0; }
     .mobile-drawer li { margin-bottom: 8px; }
     .mobile-drawer a { display: block; padding: 10px 14px; border-radius: 10px; color: var(--text-1); text-decoration: none; }
     .mobile-drawer a:hover { background: rgba(255,255,255,0.07); color: var(--text-0); }


### PR DESCRIPTION
## Summary
- allow the mobile navigation drawer list to scroll independently within the viewport
- keep the close button pinned and add safe-area padding so the drawer stays within screen bounds

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b8c46330832f8a443a7de442f46b)