### PR TITLE
Update about section heading presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,7 +406,6 @@
     <header class="tm-about__header">
       <span class="tm-about__badge" aria-hidden="true">🧰</span>
       <div class="tm-about__heading">
-        <p class="tm-about__eyebrow" aria-hidden="true">TireMasters</p>
         <h2 class="tm-about__title" id="about-title"><span class="tm-about__title-brand">TireMasters</span> — кто мы такие?</h2>
       </div>
     </header>
@@ -491,20 +490,12 @@
     .tm-about__heading {
       display: flex;
       flex-direction: column;
-      gap: 6px;
-    }
-
-    .tm-about__eyebrow {
-      margin: 0;
-      font-size: clamp(15px, 1.2vw, 18px);
-      letter-spacing: 0.14em;
-      text-transform: uppercase;
-      color: rgba(255, 255, 255, 0.6);
+      gap: 10px;
     }
 
     .tm-about__title {
       margin: 0;
-      font-size: clamp(38px, 5.4vw, 68px);
+      font-size: clamp(42px, 6.2vw, 82px);
       font-weight: 800;
       letter-spacing: 0.01em;
       line-height: 1.05;
@@ -578,12 +569,7 @@
       }
 
       .tm-about__heading {
-        gap: 4px;
-      }
-
-      .tm-about__eyebrow {
-        font-size: clamp(13px, 2.2vw, 16px);
-        letter-spacing: 0.12em;
+        gap: 6px;
       }
     }
 


### PR DESCRIPTION
## Summary
- remove the eyebrow label above the about section heading
- enlarge the main "TireMasters — кто мы такие?" title for greater emphasis

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916065294f8832fbd8211f023a2e83e)