### PR TITLE
Add SEO metadata and update title for landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,29 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>TireMasters — Header</title>
+  <title>Выездной шиномонтаж в Санкт-Петербурге | TireMasters</title>
+  <meta
+    name="description"
+    content="Выездной шиномонтаж TireMasters в Санкт-Петербурге и области: оперативный ремонт и замена шин, круглосуточный выезд мастера за 30 минут."
+  />
+  <link rel="canonical" href="https://tiremasters.pro/" />
+  <meta property="og:locale" content="ru_RU" />
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Выездной шиномонтаж в Санкт-Петербурге | TireMasters" />
+  <meta
+    property="og:description"
+    content="Выездной шиномонтаж TireMasters в Санкт-Петербурге и области: оперативный ремонт и замена шин, круглосуточный выезд мастера за 30 минут."
+  />
+  <meta property="og:url" content="https://tiremasters.pro/" />
+  <meta property="og:image" content="https://tiremasters.pro/og-image.jpg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Выездной шиномонтаж в Санкт-Петербурге | TireMasters" />
+  <meta
+    name="twitter:description"
+    content="Выездной шиномонтаж TireMasters в Санкт-Петербурге и области: оперативный ремонт и замена шин, круглосуточный выезд мастера за 30 минут."
+  />
+  <meta name="twitter:image" content="https://tiremasters.pro/og-image.jpg" />
+  <meta name="theme-color" content="#0B0D10" />
   <style>
     @import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap');
     :root {


### PR DESCRIPTION
## Summary
- update the landing page title to target the mobile tyre service keywords and location
- add meta description, canonical URL, and Open Graph/Twitter tags to improve SEO previews
- include a theme color for richer browser integration

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916a95303c0832fa99251fa86154010)