### PR TITLE
Improve readability of about section text

### DIFF
--- a/index.html
+++ b/index.html
@@ -704,13 +704,13 @@
     .tm-about__text {
       display: grid;
       gap: 18px;
-      font-size: clamp(17px, 1.25vw, 19px);
+      font-size: clamp(18px, 1.6vw, 22px);
       line-height: 1.7;
       color: var(--muted);
     }
 
     .tm-about__lead {
-      font-size: clamp(18px, 1.6vw, 20px);
+      font-size: clamp(20px, 2vw, 24px);
       color: var(--white);
       font-weight: 600;
     }


### PR DESCRIPTION
## Summary
- increase the base font size for the "Кто мы такие" section text to improve readability
- enlarge the lead paragraph sizing while keeping existing styling intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5049ec34832fb43898fba07ea172)