### PR TITLE
Adjust about section secondary text sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -711,7 +711,7 @@
 
     .tm-about__text p:not(.tm-about__lead),
     .tm-about__list {
-      font-size: clamp(18px, 1.7vw, 22px);
+      font-size: clamp(17px, 1.55vw, 21px);
     }
 
     .tm-about__lead {


### PR DESCRIPTION
## Summary
- slightly reduced the font size for secondary paragraphs and list items in the about section to make text more compact while keeping readability

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f5c51ae38832f83ca14a4f2426f17)