### PR TITLE
Increase about heading size

### DIFF
--- a/index.html
+++ b/index.html
@@ -677,9 +677,9 @@
       gap: 10px;
     }
 
-    .tm-about__title {
+    .tm-about.tm-surface--services .tm-about__title {
       margin: 0;
-      font-size: clamp(96px, 12vw, 180px);
+      font-size: clamp(112px, 13vw, 208px);
       font-weight: 800;
       letter-spacing: 0.01em;
       line-height: 1.05;


### PR DESCRIPTION
## Summary
- enlarge the About section hero heading by increasing its clamp-based font size
- scope the hero heading styles to the services About block so the new sizing is applied consistently

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f606d9ae4832f8415124dea066a3a)