### PR TITLE
Reduce About heading size

### DIFF
--- a/index.html
+++ b/index.html
@@ -677,12 +677,12 @@
       gap: 10px;
     }
 
-    .tm-about__title {
+    .tm-about.tm-surface--services .tm-about__title {
       margin: 0;
-      font-size: clamp(96px, 12vw, 180px);
+      font-size: clamp(20px, 2vw, 24px);
       font-weight: 800;
       letter-spacing: 0.01em;
-      line-height: 1.05;
+      line-height: 1.3;
       text-wrap: balance;
     }
 


### PR DESCRIPTION
## Summary
- decrease the About section heading clamp size to align with paragraph text and avoid oversized display

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f606d9ae4832f8415124dea066a3a)