### PR TITLE
Reduce about section heading size

### DIFF
--- a/index.html
+++ b/index.html
@@ -679,10 +679,10 @@
 
     .tm-about.tm-surface--services .tm-about__title {
       margin: 0;
-      font-size: clamp(112px, 13vw, 208px);
-      font-weight: 800;
-      letter-spacing: 0.01em;
-      line-height: 1.05;
+      font-size: clamp(24px, 2.6vw, 32px);
+      font-weight: 700;
+      letter-spacing: 0.02em;
+      line-height: 1.3;
       text-wrap: balance;
     }
 


### PR DESCRIPTION
## Summary
- reduce the about section heading typography to match body content scale
- maintain balanced layout without oversized title text

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f631d6d0c832f8d7ff45c343a767e)