### PR TITLE
Add Yandex address autocomplete

### DIFF
--- a/js/yandex-suggest.js
+++ b/js/yandex-suggest.js
@@ -1,1 +1,44 @@
-// Здесь позже будет логика подсказок адресов Яндекс.Карт
+// Инициализация подсказок адресов Яндекс.Карт
+ymaps.ready(initAddressSuggest);
+
+function initAddressSuggest() {
+  const addressInput =
+    document.querySelector('input[name="location"]') ||
+    document.querySelector('input[placeholder*="Адрес"]') ||
+    document.querySelector('input[placeholder*="локация"]');
+
+  if (!addressInput) {
+    console.warn('Поле адреса для подсказок не найдено');
+    return;
+  }
+
+  const suggestView = new ymaps.SuggestView(addressInput, {
+    provider: {
+      suggest(request) {
+        return ymaps.suggest(request, {
+          boundedBy: [
+            [59, 29],
+            [61, 32]
+          ],
+          strictBounds: true
+        });
+      }
+    }
+  });
+
+  suggestView.events.add('select', (event) => {
+    const value = event.get('item').value;
+
+    ymaps.geocode(value).then((res) => {
+      const firstGeoObject = res.geoObjects.get(0);
+      if (!firstGeoObject) return;
+
+      const coords = firstGeoObject.geometry.getCoordinates();
+      const coordsInput = document.querySelector('input[name="coords"]');
+
+      if (coordsInput && coords) {
+        coordsInput.value = coords.join(',');
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- initialize Yandex Maps suggest view for the address field
- restrict suggestions to Saint Petersburg and Leningrad Oblast
- store selected coordinates into the optional hidden coords input

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69204102f428832f8d13598b27a98789)