### PR TITLE
Update header navigation label and clean footer contact info

### DIFF
--- a/index.html
+++ b/index.html
@@ -351,7 +351,7 @@
       <ul>
         <li><a href="#hero">Главная</a></li>
         <li><a href="#about">Кто мы такие?</a></li>
-        <li><a href="#calc">Калькулятор</a></li>
+        <li><a href="#calc">Онлайн заявка</a></li>
         <li><a href="#promo">Спец предложение</a></li>
         <li><a href="#tow-anchor">Эвакуатор</a></li>
         <li><a href="#electrician-anchor">Автоэлектрик</a></li>
@@ -4394,7 +4394,6 @@ body {
       <span class="badge">Оплата картой</span>
     </div>
 
-    <p class="contacts-email">Почта: <a href="mailto:info@tiremasters.ru">info@tiremasters.ru</a></p>
   </div>
 </section>
 
@@ -4724,7 +4723,7 @@ body {
           <ul class="tm-nav__list" aria-label="Якоря по секциям">
             <li><a class="tm-nav__link focusable" href="#hero">Hero</a></li>
             <li><a class="tm-nav__link focusable" href="#about">Кто мы такие?</a></li>
-            <li><a class="tm-nav__link focusable" href="#calculator">Калькулятор</a></li>
+            <li><a class="tm-nav__link focusable" href="#calculator">Онлайн заявка</a></li>
             <li><a class="tm-nav__link focusable" href="#services">Услуги</a></li>
             <li><a class="tm-nav__link focusable" href="#benefits">Почему мы</a></li>
             <li><a class="tm-nav__link focusable" href="#howitworks">Как это работает</a></li>
@@ -4806,7 +4805,6 @@ body {
             </span>
           </div>
 
-          <p class="tm-address">Адрес офиса: г. Санкт‑Петербург, Невский пр., 123 (псевдо‑адрес для макета)</p>
         </section>
       </div>
     </div>
@@ -4814,10 +4812,7 @@ body {
     <div class="tm-sub" aria-label="Служебная информация">
       <div class="tm-sub__inner">
         <div class="tm-sub__left">© TireMasters</div>
-        <div class="tm-sub__links">
-          <a class="tm-sub__link focusable" href="#policy">Политика конфиденциальности</a>
-          <a class="tm-sub__link focusable" href="#offer">Публичная оферта</a>
-        </div>
+        <div class="tm-sub__links"></div>
     </div>
 
     <div class="tm-footer__tread" aria-hidden="true"></div>


### PR DESCRIPTION
## Summary
- rename the calculator menu entries to "Онлайн заявка" in header and footer navigation
- remove email contact line, office address, and policy/offer links from the footer contacts block

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692054147f80832fb79d32a4d210358d)