### PR TITLE
Adjust hero CTA button colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -517,11 +517,38 @@
 .tm-hero__subtitle{font-size:clamp(16px,1.2vw,18px);color:var(--muted);margin:0 0 20px}
 
 /* CTA */
-.btn{display:inline-flex;align-items:center;gap:10px;padding:12px 16px;border-radius:12px;text-decoration:none;transition:all var(--t) ease;box-shadow:var(--shadow)}
-.btn-primary-outline{color:#111;background:transparent;border:2px solid var(--yellow);}
-.btn-primary-outline:hover,.btn-primary-outline:focus{background:var(--yellow);color:#111;transform:translateY(-1px)}
-.btn-secondary{color:var(--white);background:transparent;border:1px solid var(--steel)}
-.btn-secondary:hover,.btn-secondary:focus{background:#1a1f27}
+  .btn{display:inline-flex;align-items:center;gap:10px;padding:12px 16px;border-radius:12px;text-decoration:none;transition:all var(--t) ease;box-shadow:var(--shadow)}
+  .btn-primary-outline{color:#111;background:transparent;border:2px solid var(--yellow);}
+  .btn-primary-outline:hover,.btn-primary-outline:focus{background:var(--yellow);color:#111;transform:translateY(-1px)}
+  .btn-secondary{color:var(--white);background:transparent;border:1px solid var(--steel)}
+  .btn-secondary:hover,.btn-secondary:focus{background:#1a1f27}
+
+  /* Цвета CTA на первом экране */
+  .tm-hero .btn-primary-outline{
+    background: var(--yellow);
+    border-color: var(--yellow);
+    color: #111;
+  }
+  .tm-hero .btn-primary-outline:hover,
+  .tm-hero .btn-primary-outline:focus{
+    background: #ffd95a;
+    border-color: #ffd95a;
+    color: #0b0d10;
+    transform: translateY(-1px);
+  }
+
+  .tm-hero .btn-secondary{
+    background: var(--red);
+    border-color: var(--red);
+    color: #0b0d10;
+  }
+  .tm-hero .btn-secondary:hover,
+  .tm-hero .btn-secondary:focus{
+    background: #ff5f5f;
+    border-color: #ff5f5f;
+    color: #0b0d10;
+    transform: translateY(-1px);
+  }
 
 .tm-hero__cta{display:flex;flex-wrap:wrap;gap:10px 14px;align-items:center;margin-bottom:14px;}
 .tm-hero__messengers{display:flex;align-items:center;gap:10px;}


### PR DESCRIPTION
## Summary
- update hero CTA styles to highlight the “Вызвать мастера” button
- recolor the “Позвонить” button in the hero to a red theme

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69205b0183a0832fa9047be3146b2329)