### PR TITLE
Add fuel delivery service card and option

### DIFF
--- a/index.html
+++ b/index.html
@@ -923,6 +923,12 @@
               <span class="hint">Шиномонтаж</span>
             </label>
             <label class="tm-service-card">
+              <input type="radio" name="service" value="fuel-delivery" required>
+              <span class="icon icon--tire" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="9"/><path d="M12 6v6l3 3"/></svg></span>
+              <span class="title">Подвоз топлива</span>
+              <span class="hint">Шиномонтаж</span>
+            </label>
+            <label class="tm-service-card">
               <input type="radio" name="service" value="computer-diagnostics" required>
               <span class="icon icon--electric" aria-hidden="true"><svg viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="12" rx="2"/><path d="M12 16v4"/><path d="M8 20h8"/></svg></span>
               <span class="title">Компьютерная диагностика</span>
@@ -3226,6 +3232,24 @@ document.addEventListener("DOMContentLoaded", () => {
           <div class="body">
             <h3>Снятие секреток</h3>
             <p>Потеряли ключ от секреток или он сломался? Не беда — мы приедем и аккуратно снимем секретные гайки без повреждения дисков. Работа выполняется с использованием профессиональных инструментов. Восстановим доступ к колесу быстро и без риска для крепежей. Это безопаснее и надёжнее, чем пытаться открутить самому.</p>
+          </div>
+          <div class="actions">
+            <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>
+            <ul class="utils" aria-label="Быстрые детали">
+              <li class="badge">24/7</li>
+              <li class="badge">СПб/ЛО</li>
+              <li class="badge">~25 мин</li>
+            </ul>
+          </div>
+        </article>
+
+        <article class="service-card">
+          <div class="media">
+            <img src="Ночной ремонт на мокрой трассе.png" alt="Подвоз топлива на трассе" loading="lazy" width="1280" height="720" />
+          </div>
+          <div class="body">
+            <h3>Подвоз топлива</h3>
+            <p>Закончилось топливо по дороге — на трассе, во дворе или за городом? Мастер TireMasters привезёт бензин или дизель нужного типа и объёма прямо к вашему автомобилю. Мы приезжаем в среднем за 25–40 минут по Санкт-Петербургу и ближайшим районам ЛО, помогаем безопасно залить топливо и, при необходимости, запустить двигатель. Вам не нужно искать канистру, открытую АЗС или просить помощи у случайных водителей — всё решим на месте.</p>
           </div>
           <div class="actions">
             <a class="btn primary" href="#calc">Вызвать шиномонтаж</a>


### PR DESCRIPTION
## Summary
- add a fuel delivery service card to the on-page services grid with consistent styling
- include the new fuel delivery option in the online request form

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c12ea1798832f8447c494090161d7)