### PR TITLE
Add multi-page navigation for service pages

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -4,10 +4,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Выездной шиномонтаж 24/7 в Санкт-Петербурге и ЛО — TireMasters</title>
+  <title>Выездной автоэлектрик 24/7 в Санкт-Петербурге и ЛО — TireMasters</title>
   <meta
     name="description"
-    content="Выездной шиномонтаж 24/7 в Санкт-Петербурге и Ленинградской области. Ремонт проколов и порезов, сезонная переобувка, установка запаски. Примерные цены от 2000 ₽, выезд от ~25 минут."
+    content="Выездной автоэлектрик в Санкт-Петербурге и Ленинградской области. Запуск двигателя, замена аккумулятора, диагностика и ремонт электрики. Примерные цены от 2000 ₽, выезд от ~25 минут."
   />
   <meta name="robots" content="index, follow" />
   <meta name="author" content="TireMasters" />
@@ -357,9 +357,9 @@
     <div class="header-inner">
       <a href="#hero" class="brand"><img src="logo.png" alt="Логотип"/><span>TireMasters</span></a>
       <nav class="tm-main-services-nav" aria-label="Выбор услуги">
-        <a href="index.html" class="tm-main-services-link tm-active">Выездной шиномонтаж</a>
+        <a href="index.html" class="tm-main-services-link">Выездной шиномонтаж</a>
         <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
-        <a href="avtoelektrik.html" class="tm-main-services-link">Автоэлектрик</a>
+        <a href="avtoelektrik.html" class="tm-main-services-link tm-active">Автоэлектрик</a>
       </nav>
       <div class="right">
         <a class="contact-icon" href="https://t.me/Tiar_MASTERSPro" target="_blank" aria-label="Telegram">
@@ -399,9 +399,9 @@
     </button>
     <div class="mobile-drawer__services">
       <nav class="tm-main-services-nav" aria-label="Выбор услуги (мобильное меню)">
-        <a href="index.html" class="tm-main-services-link tm-active">Выездной шиномонтаж</a>
+        <a href="index.html" class="tm-main-services-link">Выездной шиномонтаж</a>
         <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
-        <a href="avtoelektrik.html" class="tm-main-services-link">Автоэлектрик</a>
+        <a href="avtoelektrik.html" class="tm-main-services-link tm-active">Автоэлектрик</a>
       </nav>
     </div>
     <div class="mobile-drawer__list">

--- a/evacuator.html
+++ b/evacuator.html
@@ -4,10 +4,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Выездной шиномонтаж 24/7 в Санкт-Петербурге и ЛО — TireMasters</title>
+  <title>Эвакуатор 24/7 в Санкт-Петербурге и Ленинградской области — TireMasters</title>
   <meta
     name="description"
-    content="Выездной шиномонтаж 24/7 в Санкт-Петербурге и Ленинградской области. Ремонт проколов и порезов, сезонная переобувка, установка запаски. Примерные цены от 2000 ₽, выезд от ~25 минут."
+    content="Круглосуточный эвакуатор в Санкт-Петербурге и Ленинградской области. Эвакуация после ДТП, из кювета, с парковки и трассы. Примерные цены от 2000 ₽, выезд от ~25 минут."
   />
   <meta name="robots" content="index, follow" />
   <meta name="author" content="TireMasters" />
@@ -357,8 +357,8 @@
     <div class="header-inner">
       <a href="#hero" class="brand"><img src="logo.png" alt="Логотип"/><span>TireMasters</span></a>
       <nav class="tm-main-services-nav" aria-label="Выбор услуги">
-        <a href="index.html" class="tm-main-services-link tm-active">Выездной шиномонтаж</a>
-        <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
+        <a href="index.html" class="tm-main-services-link">Выездной шиномонтаж</a>
+        <a href="evacuator.html" class="tm-main-services-link tm-active">Эвакуатор</a>
         <a href="avtoelektrik.html" class="tm-main-services-link">Автоэлектрик</a>
       </nav>
       <div class="right">
@@ -399,8 +399,8 @@
     </button>
     <div class="mobile-drawer__services">
       <nav class="tm-main-services-nav" aria-label="Выбор услуги (мобильное меню)">
-        <a href="index.html" class="tm-main-services-link tm-active">Выездной шиномонтаж</a>
-        <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
+        <a href="index.html" class="tm-main-services-link">Выездной шиномонтаж</a>
+        <a href="evacuator.html" class="tm-main-services-link tm-active">Эвакуатор</a>
         <a href="avtoelektrik.html" class="tm-main-services-link">Автоэлектрик</a>
       </nav>
     </div>


### PR DESCRIPTION
## Summary
- split the landing into three pages (main, evacuator, avtoelektrik) with updated meta titles and descriptions for each service
- added primary service navigation with per-page active states plus secondary anchor navigation across all pages and mobile drawer
- aligned footer navigation anchors to current page sections and kept shared header/footer structure across pages

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69354c863cd8832f930d43cc10c40d6e)