### PR TITLE
Align navigation and CTAs per service pages

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -576,13 +576,27 @@
       border-bottom: 1px solid rgba(0, 0, 0, 0.5);
     }
 
-    footer {
-      padding: 28px 0 40px;
-      background: #0a0c0f;
-      color: var(--text-1);
-      text-align: center;
-      font-size: 14px;
+    .tm-footer {
+      background: #0B0D10;
+      color: #E8EAED;
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+      padding: 40px 20px 30px;
     }
+
+    .tm-footer__grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      gap: 18px;
+      max-width: 1100px;
+      margin: 0 auto;
+    }
+
+    .tm-footer h3 { margin: 0 0 10px; font-size: 18px; }
+    .tm-footer p { margin: 0 0 8px; color: #B6BBC3; }
+    .tm-footer ul { list-style: none; padding: 0; margin: 0; display: grid; gap: 6px; }
+    .tm-footer a { color: #E8EAED; text-decoration: none; }
+    .tm-footer a:hover,
+    .tm-footer a:focus-visible { text-decoration: underline; }
 
     @media (max-width: 640px) {
       body {
@@ -606,7 +620,7 @@
 <body>
   <header class="site-header">
     <div class="header-inner">
-      <a href="#hero" class="brand"><img src="logo.png" alt="Логотип" /><span>TireMasters</span></a>
+      <a href="#tm-autoelectric-hero" class="brand"><img src="logo.png" alt="Логотип" /><span>TireMasters</span></a>
       <nav class="tm-main-services-nav" aria-label="Выбор услуги">
         <a href="index.html" class="tm-main-services-link">Выездной шиномонтаж</a>
         <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
@@ -625,15 +639,13 @@
     </div>
     <nav class="tm-secondary-nav" aria-label="Навигация по странице">
       <div class="tm-secondary-nav__inner">
-        <a class="tm-secondary-nav__link" href="#hero">Главная</a>
-        <a class="tm-secondary-nav__link" href="#tm-autoelectric-situations">Когда нужен автоэлектрик</a>
+        <a class="tm-secondary-nav__link" href="#tm-autoelectric-hero">Главная</a>
+        <a class="tm-secondary-nav__link" href="#tm-autoelectric-situations">Ситуации</a>
         <a class="tm-secondary-nav__link" href="#tm-autoelectric-services">Услуги</a>
         <a class="tm-secondary-nav__link" href="#tm-autoelectric-prices">Цены</a>
         <a class="tm-secondary-nav__link" href="#tm-autoelectric-geo">География</a>
-        <a class="tm-secondary-nav__link" href="#tm-crosslinks">Другие услуги</a>
         <a class="tm-secondary-nav__link" href="#reviews">Отзывы</a>
         <a class="tm-secondary-nav__link" href="#faq">FAQ</a>
-        <a class="tm-secondary-nav__link" href="#calc">Заявка</a>
         <a class="tm-secondary-nav__link" href="#contacts">Контакты</a>
       </div>
     </nav>
@@ -654,21 +666,19 @@
     </div>
     <div class="mobile-drawer__list">
       <ul>
-        <li><a href="#hero">Главная</a></li>
-        <li><a href="#tm-autoelectric-situations">Когда нужен автоэлектрик</a></li>
+        <li><a href="#tm-autoelectric-hero">Главная</a></li>
+        <li><a href="#tm-autoelectric-situations">Ситуации</a></li>
         <li><a href="#tm-autoelectric-services">Услуги</a></li>
         <li><a href="#tm-autoelectric-prices">Цены</a></li>
         <li><a href="#tm-autoelectric-geo">География</a></li>
-        <li><a href="#tm-crosslinks">Другие услуги</a></li>
         <li><a href="#reviews">Отзывы</a></li>
         <li><a href="#faq">FAQ</a></li>
-        <li><a href="#calc">Заявка</a></li>
         <li><a href="#contacts">Контакты</a></li>
       </ul>
     </div>
   </aside>
 
-  <section id="hero" class="tm-hero" aria-label="Первый экран TireMasters">
+  <section id="tm-autoelectric-hero" class="tm-hero" aria-label="Первый экран TireMasters">
     <div class="tm-hero__container">
       <div class="tm-hero__col tm-hero__col--left">
         <h1 class="tm-hero__title">Выездной автоэлектрик 24/7 в Санкт-Петербурге и Ленинградской области</h1>
@@ -989,8 +999,35 @@
     </div>
   </section>
 
-  <footer>
-    TireMasters — выездной автоэлектрик, шиномонтаж и эвакуатор. Санкт-Петербург и Ленинградская область, 24/7.
+  <footer class="tm-footer" id="footer">
+    <div class="tm-footer__grid">
+      <div>
+        <h3>Услуги</h3>
+        <ul>
+          <li><a href="index.html">Шиномонтаж</a></li>
+          <li><a href="evacuator.html">Эвакуатор</a></li>
+          <li><a href="avtoelektrik.html">Автоэлектрик</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Навигация</h3>
+        <ul>
+          <li><a href="#tm-autoelectric-hero">Главная</a></li>
+          <li><a href="#tm-autoelectric-situations">Ситуации</a></li>
+          <li><a href="#tm-autoelectric-services">Услуги</a></li>
+          <li><a href="#tm-autoelectric-prices">Цены</a></li>
+          <li><a href="#tm-autoelectric-geo">География</a></li>
+          <li><a href="#reviews">Отзывы</a></li>
+          <li><a href="#faq">FAQ</a></li>
+          <li><a href="#contacts">Контакты</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>О TireMasters</h3>
+        <p>Выездной автоэлектрик по СПб и ЛО. Диагностика, запуск двигателя, замена аккумулятора и помощь на дороге 24/7.</p>
+        <p><a href="tel:+79531580900">+7 953 158 0900</a> — звоните или пишите в мессенджеры, подтвердим стоимость до выезда.</p>
+      </div>
+    </div>
   </footer>
 
   <script>

--- a/evacuator.html
+++ b/evacuator.html
@@ -355,7 +355,7 @@
 <body>
   <header class="site-header">
     <div class="header-inner">
-      <a href="#hero" class="brand"><img src="logo.png" alt="Логотип"/><span>TireMasters</span></a>
+      <a href="#tm-evacuator-hero" class="brand"><img src="logo.png" alt="Логотип"/><span>TireMasters</span></a>
       <nav class="tm-main-services-nav" aria-label="Выбор услуги">
         <a href="index.html" class="tm-main-services-link">Выездной шиномонтаж</a>
         <a href="evacuator.html" class="tm-main-services-link tm-active">Эвакуатор</a>
@@ -374,8 +374,8 @@
     </div>
     <nav class="tm-secondary-nav" aria-label="Навигация по странице">
       <div class="tm-secondary-nav__inner">
-        <a class="tm-secondary-nav__link" href="#hero">Главная</a>
-        <a class="tm-secondary-nav__link" href="#tow-anchor">Эвакуатор</a>
+        <a class="tm-secondary-nav__link" href="#tm-evacuator-hero">Главная</a>
+        <a class="tm-secondary-nav__link" href="#tm-evacuator-situations">Ситуации</a>
         <a class="tm-secondary-nav__link" href="#tm-evacuator-prices">Цены</a>
         <a class="tm-secondary-nav__link" href="#tm-evacuator-geo">География</a>
         <a class="tm-secondary-nav__link" href="#reviews">Отзывы</a>
@@ -400,8 +400,8 @@
     </div>
     <div class="mobile-drawer__list">
       <ul>
-        <li><a href="#hero">Главная</a></li>
-        <li><a href="#tow-anchor">Эвакуатор</a></li>
+        <li><a href="#tm-evacuator-hero">Главная</a></li>
+        <li><a href="#tm-evacuator-situations">Ситуации</a></li>
         <li><a href="#tm-evacuator-prices">Цены</a></li>
         <li><a href="#tm-evacuator-geo">География</a></li>
         <li><a href="#reviews">Отзывы</a></li>
@@ -454,7 +454,7 @@
 
 
 <!-- TM-MARK: ХЕРОЙ START -->
-<section id="hero" class="tm-hero" aria-label="Первый экран TireMasters">
+<section id="tm-evacuator-hero" class="tm-hero" aria-label="Первый экран TireMasters">
   <!-- TM-MARK: HTML START -->
   <!--
     Разумные допущения:
@@ -667,7 +667,7 @@
   </div>
 </section>
 
-<span id="tow-anchor" class="tm-anchor"></span>
+<span id="tm-evacuator-situations" class="tm-anchor"></span>
 <section id="tow" class="tm-tow tm-surface--services" aria-label="Эвакуатор 24/7 в Санкт-Петербурге и ЛО">
   <div class="tm-tow__container">
     <header class="tm-tow__head">
@@ -1022,6 +1022,36 @@
   </div>
 </section>
 
+<footer class="tm-footer" id="footer">
+  <div class="tm-footer__grid">
+    <div>
+      <h3>Услуги</h3>
+      <ul>
+        <li><a href="index.html">Шиномонтаж</a></li>
+        <li><a href="evacuator.html">Эвакуатор</a></li>
+        <li><a href="avtoelektrik.html">Автоэлектрик</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3>Навигация</h3>
+      <ul>
+        <li><a href="#tm-evacuator-hero">Главная</a></li>
+        <li><a href="#tm-evacuator-situations">Ситуации</a></li>
+        <li><a href="#tm-evacuator-prices">Цены</a></li>
+        <li><a href="#tm-evacuator-geo">География</a></li>
+        <li><a href="#reviews">Отзывы</a></li>
+        <li><a href="#faq">FAQ</a></li>
+        <li><a href="#contacts">Контакты</a></li>
+      </ul>
+    </div>
+    <div>
+      <h3>О TireMasters</h3>
+      <p>Круглосуточный эвакуатор по Санкт-Петербургу и ЛО. Подбираем технику под тип автомобиля, подтверждаем стоимость до выезда.</p>
+      <p><a href="tel:+79531580900">+7 953 158 0900</a> — звоните или пишите в мессенджеры, ответим быстро.</p>
+    </div>
+  </div>
+</footer>
+
 <style>
   .tm-crosslinks { padding: 48px 20px; background: linear-gradient(180deg, rgba(255,255,255,0.02), rgba(0,0,0,0.35)); }
   .tm-crosslinks-grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(260px,1fr)); gap: 16px; max-width: 1100px; margin: 0 auto; }
@@ -1077,6 +1107,14 @@
   .contacts-alt-text { color: #B6BBC3; margin-bottom: 12px; }
   .contacts-badges { display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; color: #FFC107; }
   .badge { border: 1px solid rgba(255,255,255,0.2); border-radius: 999px; padding: 6px 10px; }
+
+  .tm-footer { background: #0B0D10; color: #E8EAED; border-top: 1px solid rgba(255,255,255,0.08); padding: 40px 20px 30px; }
+  .tm-footer__grid { display: grid; grid-template-columns: repeat(auto-fit,minmax(240px,1fr)); gap: 18px; max-width: 1100px; margin: 0 auto; }
+  .tm-footer h3 { margin: 0 0 10px; font-size: 18px; }
+  .tm-footer p { margin: 0 0 8px; color: #B6BBC3; }
+  .tm-footer ul { list-style: none; padding: 0; margin: 0; display: grid; gap: 6px; }
+  .tm-footer a { color: #E8EAED; text-decoration: none; }
+  .tm-footer a:hover, .tm-footer a:focus-visible { text-decoration: underline; }
 
   @media (max-width: 640px) {
     .tm-table { min-width: 0; }

--- a/index.html
+++ b/index.html
@@ -459,7 +459,7 @@
 <body>
   <header class="site-header">
     <div class="header-inner">
-      <a href="#hero" class="brand"><img src="logo.png" alt="Логотип"/><span>TireMasters</span></a>
+      <a href="#tm-tyre-hero" class="brand"><img src="logo.png" alt="Логотип"/><span>TireMasters</span></a>
       <nav class="tm-main-services-nav" aria-label="Выбор услуги">
         <a href="index.html" class="tm-main-services-link tm-active">Выездной шиномонтаж</a>
         <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
@@ -472,19 +472,16 @@
         <a class="contact-icon" href="tel:+79531580900" aria-label="Позвонить">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.6 10.8c1.3 2.5 3.2 4.5 5.7 5.7l1.9-1.9c.3-.3.8-.4 1.2-.3 1 .3 2 .4 3.1.4.6 0 1 .4 1 .9v3.1c0 .6-.4 1-.9 1C10.9 20 4 13.1 4 4.9c0-.5.4-.9 1-.9H8c.6 0 1 .4 1 .9 0 1 .1 2.1.4 3.1.1.4 0 .9-.3 1.2l-1.9 1.5z" fill="currentColor"/></svg>
         </a>
-        <a class="cta-primary active" href="#calc">Вызвать мастера</a>
+        <a class="cta-primary active" href="#calc">Вызвать шиномонтаж</a>
         <div class="burger"><button aria-label="Открыть меню"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button></div>
       </div>
     </div>
     <nav class="tm-secondary-nav" aria-label="Навигация по странице">
       <div class="tm-secondary-nav__inner">
-        <a class="tm-secondary-nav__link" href="#hero">Главная</a>
-        <a class="tm-secondary-nav__link" href="#about">Кто мы такие?</a>
-        <a class="tm-secondary-nav__link" href="#cases">Кейсы</a>
-        <a class="tm-secondary-nav__link" href="#calc">Онлайн заявка</a>
-        <a class="tm-secondary-nav__link" href="#services">Услуги</a>
-        <a class="tm-secondary-nav__link" href="#how">Как это работает</a>
-        <a class="tm-secondary-nav__link" href="#geo">География</a>
+        <a class="tm-secondary-nav__link" href="#tm-tyre-hero">Главная</a>
+        <a class="tm-secondary-nav__link" href="#tm-tyre-services">Услуги</a>
+        <a class="tm-secondary-nav__link" href="#tm-tyre-prices">Цены</a>
+        <a class="tm-secondary-nav__link" href="#tm-tyre-geo">География</a>
         <a class="tm-secondary-nav__link" href="#reviews">Отзывы</a>
         <a class="tm-secondary-nav__link" href="#faq">FAQ</a>
         <a class="tm-secondary-nav__link" href="#contacts">Контакты</a>
@@ -507,13 +504,10 @@
     </div>
     <div class="mobile-drawer__list">
       <ul>
-        <li><a href="#hero">Главная</a></li>
-        <li><a href="#about">Кто мы такие?</a></li>
-        <li><a href="#cases">Кейсы</a></li>
-        <li><a href="#calc">Онлайн заявка</a></li>
-        <li><a href="#services">Услуги</a></li>
-        <li><a href="#how">Как это работает</a></li>
-        <li><a href="#geo">География</a></li>
+        <li><a href="#tm-tyre-hero">Главная</a></li>
+        <li><a href="#tm-tyre-services">Услуги</a></li>
+        <li><a href="#tm-tyre-prices">Цены</a></li>
+        <li><a href="#tm-tyre-geo">География</a></li>
         <li><a href="#reviews">Отзывы</a></li>
         <li><a href="#faq">FAQ</a></li>
         <li><a href="#contacts">Контакты</a></li>
@@ -564,7 +558,7 @@
 
 
 <!-- TM-MARK: ХЕРОЙ START -->
-<section id="hero" class="tm-hero" aria-label="Первый экран TireMasters">
+<section id="tm-tyre-hero" class="tm-hero" aria-label="Первый экран TireMasters">
   <!-- TM-MARK: HTML START -->
   <!--
     Разумные допущения:
@@ -581,7 +575,7 @@
       <p class="tm-hero__subtitle">Ремонт проколов и порезов, сезонная переобувка и помощь на дороге. Приедем в среднем за ~25 минут, работаем по всему СПб и ЛО, оплата картой.</p>
 
       <div class="tm-hero__cta">
-        <a href="#calc" class="btn btn-primary-outline" aria-label="Вызвать мастера — перейти к калькулятору">Вызвать мастера</a>
+        <a href="#calc" class="btn btn-primary-outline" aria-label="Вызвать шиномонтаж — перейти к калькулятору">Вызвать шиномонтаж</a>
         <a href="tel:+79531580900" class="btn btn-secondary" aria-label="Позвонить в TireMasters">Позвонить</a>
         <div class="tm-hero__messengers" role="group" aria-label="Мессенджеры">
           <a class="messenger-btn" href="https://wa.me/79531580900" target="_blank" rel="noopener" aria-label="Написать в WhatsApp" title="WhatsApp">
@@ -1152,7 +1146,7 @@
   <div class="modal-overlay" role="dialog" aria-modal="true" hidden>
     <div class="modal-window">
       <button class="modal-close" aria-label="Закрыть">×</button>
-      <h3>Вызвать мастера</h3>
+      <h3>Вызвать шиномонтаж</h3>
       <form class="quick-form" action="#" method="post">
         <input type="tel" placeholder="Ваш телефон" required aria-label="Телефон">
         <button type="submit">Отправить заявку</button>
@@ -1557,7 +1551,7 @@
         </fieldset>
         <!-- CTA -->
         <div class="tm-actions">
-          <button type="submit" class="btn btn-secondary" id="btnOrder">Вызвать мастера</button>
+          <button type="submit" class="btn btn-secondary" id="btnOrder">Вызвать шиномонтаж</button>
         </div>
 
         <div class="tm-alert" id="formAlert" role="alert" hidden></div>
@@ -1896,11 +1890,11 @@
       alertBox.hidden = false;
     } finally {
       btnOrder.disabled = false;
-      btnOrder.textContent = 'Вызвать мастера';
+      btnOrder.textContent = 'Вызвать шиномонтаж';
     }
   });
 
-  const geoBtn = root.querySelector('#geoBtn');
+  const geoBtn = root.querySelector('#tm-tyre-geoBtn');
   if(geoBtn){
     geoBtn.addEventListener('click', async ()=>{
       if(!navigator.geolocation) return;
@@ -2185,7 +2179,7 @@
 </head>
 <body>
   <!-- TM-MARK: SERVICES_BLOCK START -->
-  <section id="services" class="services-section tm-surface--services" aria-labelledby="services-title">
+  <section id="tm-tyre-services" class="services-section tm-surface--services" aria-labelledby="services-title">
     <div class="container">
       <div class="section-head">
         <div class="eyebrow">Наши услуги</div>
@@ -2462,7 +2456,7 @@
     </p>
   </section>
 
-  <div class="tm-anchor" id="geo"></div>
+  <div class="tm-anchor" id="tm-tyre-geo"></div>
   <section id="tm-tyre-geo" class="tm-section">
     <div class="tm-section-header">
       <h2>Где работает выездной шиномонтаж TireMasters</h2>
@@ -2578,7 +2572,7 @@
     </ol>
 
     <div class="howit__cta" role="group" aria-label="Действия">
-      <a class="btn btn--primary" href="#calc" aria-label="Вызвать мастера">Вызвать мастера</a>
+      <a class="btn btn--primary" href="#calc" aria-label="Вызвать шиномонтаж">Вызвать шиномонтаж</a>
     </div>
   </div>
 </section>
@@ -2747,7 +2741,7 @@ Assumptions (разумные допущения):
 1) Количество направлений ЛО — 6 южных направлений (если нужно, заменю на точный список).
 2) Фон — фотография ночного города + полупрозрачное стекло поверх (как выбрали). Фото — заглушка; замените на реальный файл в assets/photos/night-city.jpg.
 3) Почти все тексты — плейсхолдеры (названия районов и ETA). Вы указывали, что бейджи кликабельны и ведут к фильтру/якорю.
-4) CTA: две кнопки — "Показать на карте" и "Вызвать мастера". Текст CTA по умолчанию "Вызвать мастера".
+4) CTA: две кнопки — "Показать на карте" и "Вызвать шиномонтаж". Текст CTA по умолчанию "Вызвать шиномонтаж".
 5) Колонки: 4/2/1 для desktop/tablet/mobile.
 6) Бейджи как ссылки (<a>) с aria-label и role="button" — для семантики навигации/фильтра.
 7) Мини-метрика — ETA (~25 мин) отображается рядом с названием.
@@ -2864,7 +2858,7 @@ Assumptions (разумные допущения):
           <div class="geo-sub">Выберите район, чтобы увидеть ETA, тарифы и доступность мастеров</div>
         </div>
         <div class="geo-cta">
-          <a class="btn btn-primary" id="call-btn" href="#calc" aria-label="Вызвать мастера">Вызвать мастера</a>
+          <a class="btn btn-primary" id="call-btn" href="#calc" aria-label="Вызвать шиномонтаж">Вызвать шиномонтаж</a>
         </div>
       </div>
 
@@ -3473,7 +3467,7 @@ body {
   - Background: solid deep black (#090B0E), no gradient.
   - Layout: 2 columns on desktop/tablet; 1 column on mobile.
   - Decor: top chevron separator, bottom thin "tread" line.
-  - Menu anchors confirmed: #hero, #about, #calculator, #services, #benefits, #howitworks, #geo, #cases, #reviews, #faq, #contacts.
+  - Menu anchors confirmed: #tm-tyre-hero, #about, #calculator, #tm-tyre-services, #benefits, #howitworks, #tm-tyre-geo, #cases, #reviews, #faq, #contacts.
   - CTA button triggers tel: (no modal). Change via data-action / href.
   - Fonts assumed system; keep styles minimal to integrate with site tokens.
   - Accessibility: visible :focus, aria-labels on icons, sufficient contrast.
@@ -3641,16 +3635,22 @@ body {
           <p class="tm-about__text">TireMasters — выездной шиномонтаж в Санкт‑Петербурге и ЛО. Работаем <strong>24/7</strong>, приезжаем быстро и аккуратно. Ремонт проколов, сезонная смена, балансировка, помощь на дороге. Надёжно, чисто, по фиксированным ценам.</p>
         </section>
 
+        <nav class="tm-nav" aria-label="Смена услуги">
+          <h3 class="tm-nav__title">Услуги</h3>
+          <ul class="tm-nav__list" aria-label="Ссылки на страницы услуг">
+            <li><a class="tm-nav__link focusable" href="index.html">Шиномонтаж</a></li>
+            <li><a class="tm-nav__link focusable" href="evacuator.html">Эвакуатор</a></li>
+            <li><a class="tm-nav__link focusable" href="avtoelektrik.html">Автоэлектрик</a></li>
+          </ul>
+        </nav>
+
         <nav class="tm-nav" aria-labelledby="tm-nav-title">
           <h3 class="tm-nav__title" id="tm-nav-title">Навигация</h3>
           <ul class="tm-nav__list" aria-label="Якоря по секциям">
-            <li><a class="tm-nav__link focusable" href="index.html#hero">Главная</a></li>
-            <li><a class="tm-nav__link focusable" href="#about">Кто мы такие?</a></li>
-            <li><a class="tm-nav__link focusable" href="#cases">Кейсы</a></li>
-            <li><a class="tm-nav__link focusable" href="#calc">Онлайн заявка</a></li>
-            <li><a class="tm-nav__link focusable" href="#services">Услуги</a></li>
-            <li><a class="tm-nav__link focusable" href="#how">Как это работает</a></li>
-            <li><a class="tm-nav__link focusable" href="#geo">География</a></li>
+            <li><a class="tm-nav__link focusable" href="index.html#tm-tyre-hero">Главная</a></li>
+            <li><a class="tm-nav__link focusable" href="#tm-tyre-services">Услуги</a></li>
+            <li><a class="tm-nav__link focusable" href="#tm-tyre-prices">Цены</a></li>
+            <li><a class="tm-nav__link focusable" href="#tm-tyre-geo">География</a></li>
             <li><a class="tm-nav__link focusable" href="#reviews">Отзывы</a></li>
             <li><a class="tm-nav__link focusable" href="#faq">FAQ</a></li>
             <li><a class="tm-nav__link focusable" href="#contacts">Контакты</a></li>
@@ -3701,10 +3701,10 @@ body {
           <p class="tm-cta__hint">Мы на связи 24/7. Звоните — приедем быстро.</p>
 
           <div class="tm-cta__actions">
-            <a class="tm-btn tm-btn--primary focusable" href="tel:+79531580900" data-action="call-cta" aria-label="Вызвать мастера по телефону">
+            <a class="tm-btn tm-btn--primary focusable" href="tel:+79531580900" data-action="call-cta" aria-label="Вызвать шиномонтаж по телефону">
               <!-- phone icon -->
               <svg viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M6.6 10.8a15.5 15.5 0 006.6 6.6l2.2-2.2a1.5 1.5 0 011.5-.37 9.6 9.6 0 003 0.5 1.5 1.5 0 011.3 1.5V20a2 2 0 01-2 2A16 16 0 012 8a2 2 0 012-2h3.2a1.5 1.5 0 011.5 1.3 9.6 9.6 0 00.5 3 1.5 1.5 0 01-.37 1.5z"/></svg>
-              Вызвать мастера
+              Вызвать шиномонтаж
             </a>
             <a class="tm-btn tm-btn--ghost focusable" href="https://wa.me/79531580900" target="_blank" rel="noopener" aria-label="Написать в WhatsApp (откроется в новой вкладке)">
               <!-- WhatsApp icon -->


### PR DESCRIPTION
## Summary
- unify header, mobile, and footer navigation anchors across all three service pages
- update calls-to-action and forms to explicitly reference the page’s service
- add consistent footer sections with service switches and on-page anchor links

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935774d4c90832f8d3e43829915b54b)