### PR TITLE
Improve mobile header layout

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -598,9 +598,72 @@
     .tm-footer a:hover,
     .tm-footer a:focus-visible { text-decoration: underline; }
 
+    @media (max-width: 767px) {
+      body {
+        padding-top: 0;
+      }
+
+      header.site-header {
+        position: static;
+      }
+
+      .header-inner {
+        flex-wrap: wrap;
+        align-items: flex-start;
+        height: auto;
+        padding: 12px 16px;
+        gap: 10px;
+      }
+
+      .brand {
+        order: 1;
+        flex: 1 1 auto;
+      }
+
+      .header-cta {
+        order: 2;
+        flex: 1 0 100%;
+        width: 100%;
+        justify-content: center;
+        min-height: 48px;
+      }
+
+      .right {
+        order: 1;
+        margin-left: auto;
+      }
+
+      .tm-main-services-nav {
+        order: 3;
+        flex: 1 0 100%;
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        white-space: nowrap;
+        gap: 8px;
+        padding: 4px 0;
+      }
+
+      .tm-main-services-link {
+        display: inline-block;
+        padding: 6px 12px;
+        border-radius: 999px;
+      }
+
+      .tm-secondary-nav {
+        position: static;
+        padding: 10px 16px;
+      }
+
+      .tm-secondary-nav__inner {
+        gap: 8px;
+        white-space: nowrap;
+      }
+    }
+
     @media (max-width: 640px) {
       body {
-        padding-top: 128px;
+        padding-top: 0;
       }
 
       .header-inner {
@@ -626,6 +689,7 @@
         <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
         <a href="avtoelektrik.html" class="tm-main-services-link tm-active">Автоэлектрик</a>
       </nav>
+      <a class="cta-primary header-cta" href="#calc">Вызвать автоэлектрика</a>
       <div class="right">
         <a class="contact-icon" href="https://t.me/Tiar_MASTERSPro" target="_blank" aria-label="Telegram">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.5 13.2L9.3 17.1l3-2.3 4.4 3.2 2.9-13.7L3 9.2l4.6 1.4 10.7-6.7L9.5 13.2z" fill="currentColor"/></svg>
@@ -633,7 +697,6 @@
         <a class="contact-icon" href="tel:+79531580900" aria-label="Позвонить">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.6 10.8c1.3 2.5 3.2 4.5 5.7 5.7l1.9-1.9c.3-.3.8-.4 1.2-.3 1 .3 2 .4 3.1.4.6 0 1 .4 1 .9v3.1c0 .6-.4 1-.9 1C10.9 20 4 13.1 4 4.9c0-.5.4-.9 1-.9H8c.6 0 1 .4 1 .9 0 1 .1 2.1.4 3.1.1.4 0 .9-.3 1.2l-1.9 1.5z" fill="currentColor"/></svg>
         </a>
-        <a class="cta-primary" href="#calc">Вызвать автоэлектрика</a>
         <div class="burger"><button aria-label="Открыть меню"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button></div>
       </div>
     </div>

--- a/evacuator.html
+++ b/evacuator.html
@@ -293,6 +293,73 @@
       }
     }
 
+    @media (max-width: 767px) {
+      :root {
+        --header-offset: 0px;
+      }
+
+      body {
+        padding-top: 0;
+      }
+
+      header.site-header {
+        position: static;
+      }
+
+      .header-inner {
+        flex-wrap: wrap;
+        align-items: flex-start;
+        height: auto;
+        padding: 12px 16px;
+        gap: 10px;
+      }
+
+      .brand {
+        order: 1;
+        flex: 1 1 auto;
+      }
+
+      .header-cta {
+        order: 2;
+        flex: 1 0 100%;
+        width: 100%;
+        justify-content: center;
+        min-height: 48px;
+      }
+
+      .right {
+        order: 1;
+        margin-left: auto;
+      }
+
+      .tm-main-services-nav {
+        order: 3;
+        flex: 1 0 100%;
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        white-space: nowrap;
+        gap: 8px;
+        padding: 4px 0;
+      }
+
+      .tm-main-services-link {
+        display: inline-block;
+        padding: 6px 12px;
+        border-radius: 999px;
+      }
+
+      .tm-secondary-nav {
+        position: static;
+        padding: 10px 16px;
+      }
+
+      .tm-secondary-nav__inner {
+        gap: 8px;
+        white-space: nowrap;
+      }
+    }
+
     /* Drawer */
     .mobile-drawer { position: fixed; top: 0; right: 0; bottom: 0; width: min(85vw,340px); background: #0E1116; transform: translateX(100%);
       transition: transform var(--anim-mid) ease; z-index: 1500; padding: calc(16px + env(safe-area-inset-top, 0)) 16px calc(16px + env(safe-area-inset-bottom, 0)); display: flex;
@@ -361,6 +428,7 @@
         <a href="evacuator.html" class="tm-main-services-link tm-active">Эвакуатор</a>
         <a href="avtoelektrik.html" class="tm-main-services-link">Автоэлектрик</a>
       </nav>
+      <a class="cta-primary active header-cta" href="#tow-form">Вызвать эвакуатор</a>
       <div class="right">
         <a class="contact-icon" href="https://t.me/Tiar_MASTERSPro" target="_blank" aria-label="Telegram">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.5 13.2L9.3 17.1l3-2.3 4.4 3.2 2.9-13.7L3 9.2l4.6 1.4 10.7-6.7L9.5 13.2z" fill="currentColor"/></svg>
@@ -368,7 +436,6 @@
         <a class="contact-icon" href="tel:+79531580900" aria-label="Позвонить">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.6 10.8c1.3 2.5 3.2 4.5 5.7 5.7l1.9-1.9c.3-.3.8-.4 1.2-.3 1 .3 2 .4 3.1.4.6 0 1 .4 1 .9v3.1c0 .6-.4 1-.9 1C10.9 20 4 13.1 4 4.9c0-.5.4-.9 1-.9H8c.6 0 1 .4 1 .9 0 1 .1 2.1.4 3.1.1.4 0 .9-.3 1.2l-1.9 1.5z" fill="currentColor"/></svg>
         </a>
-        <a class="cta-primary active" href="#tow-form">Вызвать эвакуатор</a>
         <div class="burger"><button aria-label="Открыть меню"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button></div>
       </div>
     </div>
@@ -438,9 +505,17 @@
       if (!header) return;
 
       const height = header.getBoundingClientRect().height;
+      const isMobile = window.matchMedia('(max-width: 767px)').matches;
+
       document.documentElement.style.setProperty('--header-height', `${height}px`);
-      document.documentElement.style.setProperty('--header-offset', `${height}px`);
-      document.body.style.paddingTop = `${height}px`;
+
+      if (isMobile) {
+        document.documentElement.style.setProperty('--header-offset', '0px');
+        document.body.style.paddingTop = '0px';
+      } else {
+        document.documentElement.style.setProperty('--header-offset', `${height}px`);
+        document.body.style.paddingTop = `${height}px`;
+      }
     }
 
     updateHeaderOffset();

--- a/index.html
+++ b/index.html
@@ -293,6 +293,73 @@
       }
     }
 
+    @media (max-width: 767px) {
+      :root {
+        --header-offset: 0px;
+      }
+
+      body {
+        padding-top: 0;
+      }
+
+      header.site-header {
+        position: static;
+      }
+
+      .header-inner {
+        flex-wrap: wrap;
+        align-items: flex-start;
+        height: auto;
+        padding: 12px 16px;
+        gap: 10px;
+      }
+
+      .brand {
+        order: 1;
+        flex: 1 1 auto;
+      }
+
+      .header-cta {
+        order: 2;
+        flex: 1 0 100%;
+        width: 100%;
+        justify-content: center;
+        min-height: 48px;
+      }
+
+      .right {
+        order: 1;
+        margin-left: auto;
+      }
+
+      .tm-main-services-nav {
+        order: 3;
+        flex: 1 0 100%;
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        white-space: nowrap;
+        gap: 8px;
+        padding: 4px 0;
+      }
+
+      .tm-main-services-link {
+        display: inline-block;
+        padding: 6px 12px;
+        border-radius: 999px;
+      }
+
+      .tm-secondary-nav {
+        position: static;
+        padding: 10px 16px;
+      }
+
+      .tm-secondary-nav__inner {
+        gap: 8px;
+        white-space: nowrap;
+      }
+    }
+
     /* Drawer */
     .mobile-drawer { position: fixed; top: 0; right: 0; bottom: 0; width: min(85vw,340px); background: #0E1116; transform: translateX(100%);
       transition: transform var(--anim-mid) ease; z-index: 1500; padding: calc(16px + env(safe-area-inset-top, 0)) 16px calc(16px + env(safe-area-inset-bottom, 0)); display: flex;
@@ -465,6 +532,7 @@
         <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
         <a href="avtoelektrik.html" class="tm-main-services-link">Автоэлектрик</a>
       </nav>
+      <a class="cta-primary active header-cta" href="#calc">Вызвать шиномонтаж</a>
       <div class="right">
         <a class="contact-icon" href="https://t.me/Tiar_MASTERSPro" target="_blank" aria-label="Telegram">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M9.5 13.2L9.3 17.1l3-2.3 4.4 3.2 2.9-13.7L3 9.2l4.6 1.4 10.7-6.7L9.5 13.2z" fill="currentColor"/></svg>
@@ -472,7 +540,6 @@
         <a class="contact-icon" href="tel:+79531580900" aria-label="Позвонить">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.6 10.8c1.3 2.5 3.2 4.5 5.7 5.7l1.9-1.9c.3-.3.8-.4 1.2-.3 1 .3 2 .4 3.1.4.6 0 1 .4 1 .9v3.1c0 .6-.4 1-.9 1C10.9 20 4 13.1 4 4.9c0-.5.4-.9 1-.9H8c.6 0 1 .4 1 .9 0 1 .1 2.1.4 3.1.1.4 0 .9-.3 1.2l-1.9 1.5z" fill="currentColor"/></svg>
         </a>
-        <a class="cta-primary active" href="#calc">Вызвать шиномонтаж</a>
         <div class="burger"><button aria-label="Открыть меню"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 6h18M3 12h18M3 18h18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button></div>
       </div>
     </div>
@@ -542,9 +609,17 @@
       if (!header) return;
 
       const height = header.getBoundingClientRect().height;
+      const isMobile = window.matchMedia('(max-width: 767px)').matches;
+
       document.documentElement.style.setProperty('--header-height', `${height}px`);
-      document.documentElement.style.setProperty('--header-offset', `${height}px`);
-      document.body.style.paddingTop = `${height}px`;
+
+      if (isMobile) {
+        document.documentElement.style.setProperty('--header-offset', '0px');
+        document.body.style.paddingTop = '0px';
+      } else {
+        document.documentElement.style.setProperty('--header-offset', `${height}px`);
+        document.body.style.paddingTop = `${height}px`;
+      }
     }
 
     updateHeaderOffset();


### PR DESCRIPTION
## Summary
- reorganized header markup so the main CTA is a separate block from the icon controls across all landing pages
- added mobile-specific styling to wrap header elements into distinct rows and enable scrollable service/page navigation strips without overlap
- updated mobile header offset handling to disable sticky behavior and prevent the hero content from being covered

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69357a1b94ec832fa642e89c24639f8d)