### PR TITLE
Update service tab active styling to match CTA

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -135,9 +135,9 @@
     }
 
     .tm-main-services-link.tm-active {
-      background: rgba(255, 193, 7, 0.2);
+      background: var(--accent-yellow);
       color: #111;
-      box-shadow: 0 0 0 1px rgba(255, 193, 7, 0.35), 0 4px 14px rgba(0, 0, 0, 0.35);
+      box-shadow: 0 0 12px rgba(255, 193, 7, 0.4), 0 4px 14px rgba(0, 0, 0, 0.35);
     }
 
     .right {

--- a/evacuator.html
+++ b/evacuator.html
@@ -242,7 +242,7 @@
     .tm-main-services-nav { display: flex; align-items: center; gap: 10px; flex: 1; justify-content: center; flex-wrap: wrap; min-width: 0; }
     .tm-main-services-link { padding: 10px 14px; border-radius: 10px; text-decoration: none; color: var(--text-0); background: rgba(255,255,255,0.04); font-weight: 600; transition: background var(--anim-mid) ease, color var(--anim-mid) ease, box-shadow var(--anim-mid) ease; white-space: nowrap; }
     .tm-main-services-link:hover, .tm-main-services-link:focus-visible { background: rgba(255,255,255,0.08); outline: none; }
-    .tm-main-services-link.tm-active { background: rgba(255,193,7,0.2); color: #111; box-shadow: 0 0 0 1px rgba(255,193,7,0.35), 0 4px 14px rgba(0,0,0,0.35); }
+    .tm-main-services-link.tm-active { background: var(--accent-yellow); color: #111; box-shadow: 0 0 12px rgba(255,193,7,0.4), 0 4px 14px rgba(0,0,0,0.35); }
 
     .right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
 

--- a/index.html
+++ b/index.html
@@ -242,7 +242,7 @@
     .tm-main-services-nav { display: flex; align-items: center; gap: 10px; flex: 1; justify-content: center; flex-wrap: wrap; min-width: 0; }
     .tm-main-services-link { padding: 10px 14px; border-radius: 10px; text-decoration: none; color: var(--text-0); background: rgba(255,255,255,0.04); font-weight: 600; transition: background var(--anim-mid) ease, color var(--anim-mid) ease, box-shadow var(--anim-mid) ease; white-space: nowrap; }
     .tm-main-services-link:hover, .tm-main-services-link:focus-visible { background: rgba(255,255,255,0.08); outline: none; }
-    .tm-main-services-link.tm-active { background: rgba(255,193,7,0.2); color: #111; box-shadow: 0 0 0 1px rgba(255,193,7,0.35), 0 4px 14px rgba(0,0,0,0.35); }
+    .tm-main-services-link.tm-active { background: var(--accent-yellow); color: #111; box-shadow: 0 0 12px rgba(255,193,7,0.4), 0 4px 14px rgba(0,0,0,0.35); }
 
     .right { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
 


### PR DESCRIPTION
## Summary
- update active service tab background to use the primary accent yellow
- keep text dark and add subtle glow for consistency with CTA styling across header and mobile menu

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69357f343250832fb1cdf4cefe401177)