### PR TITLE
Fix autoelectric active tab styling

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -49,6 +49,7 @@
       --surface-strong: rgba(255, 255, 255, 0.08);
       --text-0: #e8eaed;
       --text-1: #b6bbc3;
+      --accent-yellow: #ffc107;
       --accent: #ffc107;
       --muted: #8e949f;
       --focus: rgba(41, 182, 246, 0.6);


### PR DESCRIPTION
## Summary
- add the missing accent yellow token to the avtoelektrik page so the active service tab matches other pages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693582a6886c832fbbac15a56e1c84eb)