### PR TITLE
Hide header navigation on mobile

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -635,6 +635,11 @@
         margin-left: auto;
       }
 
+      .site-header .tm-main-services-nav,
+      .tm-secondary-nav {
+        display: none;
+      }
+
       .tm-main-services-nav {
         order: 3;
         flex: 1 0 100%;

--- a/evacuator.html
+++ b/evacuator.html
@@ -332,6 +332,11 @@
         margin-left: auto;
       }
 
+      .site-header .tm-main-services-nav,
+      .tm-secondary-nav {
+        display: none;
+      }
+
       .tm-main-services-nav {
         order: 3;
         flex: 1 0 100%;

--- a/index.html
+++ b/index.html
@@ -332,6 +332,11 @@
         margin-left: auto;
       }
 
+      .site-header .tm-main-services-nav,
+      .tm-secondary-nav {
+        display: none;
+      }
+
       .tm-main-services-nav {
         order: 3;
         flex: 1 0 100%;


### PR DESCRIPTION
## Summary
- hide the header service switcher and secondary navigation on mobile widths while keeping drawer menu options

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693586b59e30832fb9c539b94a69c199)