### PR TITLE
Refine mobile drawer navigation layout

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -227,10 +227,10 @@
       transform: translateX(100%);
       transition: transform 200ms ease;
       z-index: 1500;
-      padding: 16px;
+      padding: calc(16px + env(safe-area-inset-top, 0)) 12px calc(16px + env(safe-area-inset-bottom, 0));
       display: flex;
       flex-direction: column;
-      gap: 12px;
+      gap: 8px;
       overflow: hidden;
       max-height: 100vh;
     }
@@ -253,38 +253,87 @@
       cursor: pointer;
     }
 
-    .mobile-drawer__services .tm-main-services-nav {
-      flex-direction: column;
-      align-items: stretch;
+    .tm-drawer-section {
+      padding: 12px 16px;
     }
 
-    .mobile-drawer__list {
-      flex: 1 1 auto;
-      overflow-y: auto;
-      padding-right: 4px;
+    .tm-drawer-label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      opacity: 0.6;
+      margin-bottom: 6px;
     }
 
-    .mobile-drawer ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
+    .tm-drawer-section--services {
       display: flex;
       flex-direction: column;
       gap: 8px;
     }
 
-    .mobile-drawer a {
-      display: block;
-      padding: 10px 14px;
-      border-radius: 10px;
-      color: var(--text-1);
-      text-decoration: none;
-      background: var(--surface);
+    .tm-drawer-section--services .tm-main-services-nav {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      align-items: stretch;
     }
 
-    .mobile-drawer a:hover {
-      background: var(--surface-strong);
+    .tm-drawer-section--services .tm-main-services-link {
+      display: block;
+      width: 100%;
+      text-align: center;
+      padding: 10px 12px;
+      border-radius: 999px;
+      font-size: 15px;
+      line-height: 1.2;
+    }
+
+    .tm-drawer-section--services .tm-main-services-link:not(.tm-active) {
+      background-color: rgba(255, 255, 255, 0.08);
       color: var(--text-0);
+    }
+
+    .tm-drawer-section--services .tm-main-services-link.tm-active {
+      background-color: var(--accent-yellow);
+      color: #000;
+      font-weight: 600;
+      box-shadow: 0 0 16px rgba(255, 193, 7, 0.55);
+    }
+
+    .tm-drawer-section--page {
+      flex: 1 1 auto;
+      min-height: 0;
+      padding-top: 8px;
+      border-top: 1px solid rgba(255, 255, 255, 0.06);
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      overflow-y: auto;
+      padding-right: 8px;
+    }
+
+    .tm-drawer-page-nav {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      margin: 0;
+      padding: 0;
+    }
+
+    .tm-drawer-section--page a {
+      display: flex;
+      align-items: center;
+      padding: 8px 4px;
+      border-radius: 8px;
+      font-size: 15px;
+      line-height: 1.3;
+      color: var(--text-0);
+      text-decoration: none;
+    }
+
+    .tm-drawer-section--page a:active,
+    .tm-drawer-section--page a:focus-visible {
+      background: rgba(255, 255, 255, 0.04);
     }
 
     body.drawer-open {
@@ -730,24 +779,26 @@
         <path d="M6 6l12 12M18 6 6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
       </svg>
     </button>
-    <div class="mobile-drawer__services">
+    <div class="tm-drawer-section tm-drawer-section--services">
+      <div class="tm-drawer-label">Услуга</div>
       <nav class="tm-main-services-nav" aria-label="Выбор услуги (мобильное меню)">
         <a href="index.html" class="tm-main-services-link">Выездной шиномонтаж</a>
         <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
         <a href="avtoelektrik.html" class="tm-main-services-link tm-active">Автоэлектрик</a>
       </nav>
     </div>
-    <div class="mobile-drawer__list">
-      <ul>
-        <li><a href="#tm-autoelectric-hero">Главная</a></li>
-        <li><a href="#tm-autoelectric-situations">Ситуации</a></li>
-        <li><a href="#tm-autoelectric-services">Услуги</a></li>
-        <li><a href="#tm-autoelectric-prices">Цены</a></li>
-        <li><a href="#tm-autoelectric-geo">География</a></li>
-        <li><a href="#reviews">Отзывы</a></li>
-        <li><a href="#faq">FAQ</a></li>
-        <li><a href="#contacts">Контакты</a></li>
-      </ul>
+    <div class="tm-drawer-section tm-drawer-section--page">
+      <div class="tm-drawer-label">Разделы страницы</div>
+      <nav class="tm-drawer-page-nav" aria-label="Разделы страницы (мобильное меню)">
+        <a href="#tm-autoelectric-hero">Главная</a>
+        <a href="#tm-autoelectric-situations">Ситуации</a>
+        <a href="#tm-autoelectric-services">Услуги</a>
+        <a href="#tm-autoelectric-prices">Цены</a>
+        <a href="#tm-autoelectric-geo">География</a>
+        <a href="#reviews">Отзывы</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contacts">Контакты</a>
+      </nav>
     </div>
   </aside>
 

--- a/evacuator.html
+++ b/evacuator.html
@@ -370,23 +370,35 @@
 
     /* Drawer */
     .mobile-drawer { position: fixed; top: 0; right: 0; bottom: 0; width: min(85vw,340px); background: #0E1116; transform: translateX(100%);
-      transition: transform var(--anim-mid) ease; z-index: 1500; padding: calc(16px + env(safe-area-inset-top, 0)) 16px calc(16px + env(safe-area-inset-bottom, 0)); display: flex;
-      flex-direction: column; gap: 12px; overflow: hidden; min-height: 0; max-height: 100vh; }
+      transition: transform var(--anim-mid) ease; z-index: 1500; padding: calc(16px + env(safe-area-inset-top, 0)) 12px calc(16px + env(safe-area-inset-bottom, 0)); display: flex;
+      flex-direction: column; gap: 8px; overflow: hidden; min-height: 0; max-height: 100vh; }
     .mobile-drawer.open { transform: translateX(0); }
     .mobile-drawer__close { display: inline-flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: auto;
       border: none; border-radius: 12px; background: rgba(255,255,255,0.08); color: var(--text-0); cursor: pointer; transition: background var(--anim-mid) ease, color var(--anim-mid) ease; position: sticky; top: 0; right: 0; z-index: 1; }
     .mobile-drawer__close:hover { background: rgba(255,255,255,0.16); color: #fff; }
     .mobile-drawer__close:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--focus); background: rgba(255,255,255,0.16); color: #fff; }
     .mobile-drawer__close svg { pointer-events: none; }
-    .mobile-drawer__services { padding: 0 4px; }
-    .mobile-drawer__services .tm-main-services-nav { flex-direction: column; align-items: stretch; }
-    .mobile-drawer__services .tm-main-services-link { width: 100%; text-align: center; }
-    .mobile-drawer__list { flex: 1 1 auto; min-height: 0; overflow-y: auto; margin-top: 8px; padding-right: 4px; -webkit-overflow-scrolling: touch; }
-    .mobile-drawer__list::-webkit-scrollbar { width: 6px; }
-    .mobile-drawer__list::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.18); border-radius: 10px; }
-    .mobile-drawer ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
-    .mobile-drawer a { display: block; padding: 10px 14px; border-radius: 10px; color: var(--text-1); text-decoration: none; }
-    .mobile-drawer a:hover { background: rgba(255,255,255,0.07); color: var(--text-0); }
+    .tm-drawer-section { padding: 12px 16px; }
+
+    .tm-drawer-label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      opacity: 0.6;
+      margin-bottom: 6px;
+    }
+
+    .tm-drawer-section--services { display: flex; flex-direction: column; gap: 8px; }
+    .tm-drawer-section--services .tm-main-services-nav { display: flex; flex-direction: column; gap: 8px; align-items: stretch; }
+    .tm-drawer-section--services .tm-main-services-link { display: block; width: 100%; text-align: center; padding: 10px 12px; border-radius: 999px; font-size: 15px; line-height: 1.2; }
+    .tm-drawer-section--services .tm-main-services-link:not(.tm-active) { background-color: rgba(255,255,255,0.08); color: var(--text-0); }
+    .tm-drawer-section--services .tm-main-services-link.tm-active { background-color: var(--accent-yellow); color: #000; font-weight: 600; box-shadow: 0 0 16px rgba(255, 193, 7, 0.55); }
+
+    .tm-drawer-section--page { flex: 1 1 auto; min-height: 0; padding-top: 8px; border-top: 1px solid rgba(255, 255, 255, 0.06); display: flex; flex-direction: column; gap: 4px; overflow-y: auto; padding-right: 8px; }
+    .tm-drawer-page-nav { display: flex; flex-direction: column; gap: 4px; margin: 0; padding: 0; }
+    .tm-drawer-section--page a { display: flex; align-items: center; padding: 8px 4px; border-radius: 8px; font-size: 15px; line-height: 1.3; color: var(--text-0); text-decoration: none; }
+    .tm-drawer-section--page a:active,
+    .tm-drawer-section--page a:focus-visible { background-color: rgba(255, 255, 255, 0.04); }
 
     .tm-anchor {
       position: relative;
@@ -466,23 +478,25 @@
         <path d="M6 6l12 12M18 6 6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </button>
-    <div class="mobile-drawer__services">
+    <div class="tm-drawer-section tm-drawer-section--services">
+      <div class="tm-drawer-label">Услуга</div>
       <nav class="tm-main-services-nav" aria-label="Выбор услуги (мобильное меню)">
         <a href="index.html" class="tm-main-services-link">Выездной шиномонтаж</a>
         <a href="evacuator.html" class="tm-main-services-link tm-active">Эвакуатор</a>
         <a href="avtoelektrik.html" class="tm-main-services-link">Автоэлектрик</a>
       </nav>
     </div>
-    <div class="mobile-drawer__list">
-      <ul>
-        <li><a href="#tm-evacuator-hero">Главная</a></li>
-        <li><a href="#tm-evacuator-situations">Ситуации</a></li>
-        <li><a href="#tm-evacuator-prices">Цены</a></li>
-        <li><a href="#tm-evacuator-geo">География</a></li>
-        <li><a href="#reviews">Отзывы</a></li>
-        <li><a href="#faq">FAQ</a></li>
-        <li><a href="#contacts">Контакты</a></li>
-      </ul>
+    <div class="tm-drawer-section tm-drawer-section--page">
+      <div class="tm-drawer-label">Разделы страницы</div>
+      <nav class="tm-drawer-page-nav" aria-label="Разделы страницы (мобильное меню)">
+        <a href="#tm-evacuator-hero">Главная</a>
+        <a href="#tm-evacuator-situations">Ситуации</a>
+        <a href="#tm-evacuator-prices">Цены</a>
+        <a href="#tm-evacuator-geo">География</a>
+        <a href="#reviews">Отзывы</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contacts">Контакты</a>
+      </nav>
     </div>
   </aside>
 

--- a/index.html
+++ b/index.html
@@ -370,23 +370,35 @@
 
     /* Drawer */
     .mobile-drawer { position: fixed; top: 0; right: 0; bottom: 0; width: min(85vw,340px); background: #0E1116; transform: translateX(100%);
-      transition: transform var(--anim-mid) ease; z-index: 1500; padding: calc(16px + env(safe-area-inset-top, 0)) 16px calc(16px + env(safe-area-inset-bottom, 0)); display: flex;
-      flex-direction: column; gap: 12px; overflow: hidden; min-height: 0; max-height: 100vh; }
+      transition: transform var(--anim-mid) ease; z-index: 1500; padding: calc(16px + env(safe-area-inset-top, 0)) 12px calc(16px + env(safe-area-inset-bottom, 0)); display: flex;
+      flex-direction: column; gap: 8px; overflow: hidden; min-height: 0; max-height: 100vh; }
     .mobile-drawer.open { transform: translateX(0); }
     .mobile-drawer__close { display: inline-flex; align-items: center; justify-content: center; width: 44px; height: 44px; margin-left: auto;
       border: none; border-radius: 12px; background: rgba(255,255,255,0.08); color: var(--text-0); cursor: pointer; transition: background var(--anim-mid) ease, color var(--anim-mid) ease; position: sticky; top: 0; right: 0; z-index: 1; }
     .mobile-drawer__close:hover { background: rgba(255,255,255,0.16); color: #fff; }
     .mobile-drawer__close:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--focus); background: rgba(255,255,255,0.16); color: #fff; }
     .mobile-drawer__close svg { pointer-events: none; }
-    .mobile-drawer__services { padding: 0 4px; }
-    .mobile-drawer__services .tm-main-services-nav { flex-direction: column; align-items: stretch; }
-    .mobile-drawer__services .tm-main-services-link { width: 100%; text-align: center; }
-    .mobile-drawer__list { flex: 1 1 auto; min-height: 0; overflow-y: auto; margin-top: 8px; padding-right: 4px; -webkit-overflow-scrolling: touch; }
-    .mobile-drawer__list::-webkit-scrollbar { width: 6px; }
-    .mobile-drawer__list::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.18); border-radius: 10px; }
-    .mobile-drawer ul { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
-    .mobile-drawer a { display: block; padding: 10px 14px; border-radius: 10px; color: var(--text-1); text-decoration: none; }
-    .mobile-drawer a:hover { background: rgba(255,255,255,0.07); color: var(--text-0); }
+    .tm-drawer-section { padding: 12px 16px; }
+
+    .tm-drawer-label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      opacity: 0.6;
+      margin-bottom: 6px;
+    }
+
+    .tm-drawer-section--services { display: flex; flex-direction: column; gap: 8px; }
+    .tm-drawer-section--services .tm-main-services-nav { display: flex; flex-direction: column; gap: 8px; align-items: stretch; }
+    .tm-drawer-section--services .tm-main-services-link { display: block; width: 100%; text-align: center; padding: 10px 12px; border-radius: 999px; font-size: 15px; line-height: 1.2; }
+    .tm-drawer-section--services .tm-main-services-link:not(.tm-active) { background-color: rgba(255,255,255,0.08); color: var(--text-0); }
+    .tm-drawer-section--services .tm-main-services-link.tm-active { background-color: var(--accent-yellow); color: #000; font-weight: 600; box-shadow: 0 0 16px rgba(255, 193, 7, 0.55); }
+
+    .tm-drawer-section--page { flex: 1 1 auto; min-height: 0; padding-top: 8px; border-top: 1px solid rgba(255, 255, 255, 0.06); display: flex; flex-direction: column; gap: 4px; overflow-y: auto; padding-right: 8px; }
+    .tm-drawer-page-nav { display: flex; flex-direction: column; gap: 4px; margin: 0; padding: 0; }
+    .tm-drawer-section--page a { display: flex; align-items: center; padding: 8px 4px; border-radius: 8px; font-size: 15px; line-height: 1.3; color: var(--text-0); text-decoration: none; }
+    .tm-drawer-section--page a:active,
+    .tm-drawer-section--page a:focus-visible { background-color: rgba(255, 255, 255, 0.04); }
 
     .tm-anchor {
       position: relative;
@@ -570,23 +582,25 @@
         <path d="M6 6l12 12M18 6 6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
     </button>
-    <div class="mobile-drawer__services">
+    <div class="tm-drawer-section tm-drawer-section--services">
+      <div class="tm-drawer-label">Услуга</div>
       <nav class="tm-main-services-nav" aria-label="Выбор услуги (мобильное меню)">
         <a href="index.html" class="tm-main-services-link tm-active">Выездной шиномонтаж</a>
         <a href="evacuator.html" class="tm-main-services-link">Эвакуатор</a>
         <a href="avtoelektrik.html" class="tm-main-services-link">Автоэлектрик</a>
       </nav>
     </div>
-    <div class="mobile-drawer__list">
-      <ul>
-        <li><a href="#tm-tyre-hero">Главная</a></li>
-        <li><a href="#tm-tyre-services">Услуги</a></li>
-        <li><a href="#tm-tyre-prices">Цены</a></li>
-        <li><a href="#tm-tyre-geo">География</a></li>
-        <li><a href="#reviews">Отзывы</a></li>
-        <li><a href="#faq">FAQ</a></li>
-        <li><a href="#contacts">Контакты</a></li>
-      </ul>
+    <div class="tm-drawer-section tm-drawer-section--page">
+      <div class="tm-drawer-label">Разделы страницы</div>
+      <nav class="tm-drawer-page-nav" aria-label="Разделы страницы (мобильное меню)">
+        <a href="#tm-tyre-hero">Главная</a>
+        <a href="#tm-tyre-services">Услуги</a>
+        <a href="#tm-tyre-prices">Цены</a>
+        <a href="#tm-tyre-geo">География</a>
+        <a href="#reviews">Отзывы</a>
+        <a href="#faq">FAQ</a>
+        <a href="#contacts">Контакты</a>
+      </nav>
     </div>
   </aside>
 


### PR DESCRIPTION
## Summary
- restructure mobile drawer into service and page sections with labels
- stack service switches vertically with full-width styling and improved active state
- slim down page section links with lighter spacing and divider for hierarchy

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69358843ddc4832f8bbd8c0e07ccd1c9)