### PR TITLE
Ensure solid dark backgrounds for pricing and geo sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,6 +441,20 @@
       padding: clamp(44px, 6vw, 80px) 16px;
     }
 
+    /* Тёмный фон для секций с ценами и географией без полос */
+    #tm-tyre-prices,
+    #tm-tyre-geo {
+      background-color: var(--bg-0);
+      background-image: none;
+    }
+
+    #tm-tyre-prices::before,
+    #tm-tyre-prices::after,
+    #tm-tyre-geo::before,
+    #tm-tyre-geo::after {
+      content: none;
+    }
+
     .tm-section-header {
       max-width: 1100px;
       margin: 0 auto 20px;


### PR DESCRIPTION
## Summary
- add solid dark backgrounds for the pricing and geography sections to remove striped overlay
- disable background pseudo-elements on these sections to keep the surface flat

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935a86ee97c832fb8daf30d342e4db7)