### PR TITLE
Connect request forms to Telegram bot

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -977,6 +977,68 @@
     </form>
   </section>
 
+  <script>
+    const autoElectricForm = document.querySelector('.tm-form');
+
+    if (autoElectricForm) {
+      const status = document.createElement('p');
+      status.className = 'tm-form__status';
+      status.style.margin = '0';
+      status.style.color = '#B6BBC3';
+      status.setAttribute('role', 'status');
+      status.hidden = true;
+      autoElectricForm.appendChild(status);
+
+      const submitBtn = autoElectricForm.querySelector('button[type="submit"]');
+
+      autoElectricForm.addEventListener('submit', async (event) => {
+        event.preventDefault();
+
+        if (!autoElectricForm.reportValidity()) return;
+
+        status.textContent = 'Отправляем заявку…';
+        status.hidden = false;
+        submitBtn.disabled = true;
+
+        const formData = new FormData(autoElectricForm);
+        const name = (formData.get('name') || '').toString().trim();
+        const phone = (formData.get('phone') || '').toString().trim();
+        const location = (formData.get('location') || '').toString().trim();
+        const issue = (formData.get('issue') || '').toString().trim();
+
+        const message = [
+          '🔌 Заявка на выезд автоэлектрика',
+          name ? `Имя: ${name}` : 'Имя не указано',
+          `Телефон: ${phone || '—'}`,
+          location ? `Адрес/ориентир: ${location}` : 'Адрес не указан',
+          issue ? `Описание: ${issue}` : 'Описание: —',
+        ].join('\n');
+
+        try {
+          const response = await fetch('/api/sendToTelegram', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, phone, location, message }),
+          });
+
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok || data.ok === false) {
+            const text = data?.error || data?.description || (!response.ok ? await response.text() : '');
+            throw new Error(text || 'Не удалось отправить заявку. Попробуйте ещё раз.');
+          }
+
+          status.textContent = 'Спасибо! Мы свяжемся с вами для уточнения деталей.';
+          autoElectricForm.reset();
+        } catch (error) {
+          console.error(error);
+          status.textContent = `Ошибка отправки: ${error?.message || 'Попробуйте ещё раз или свяжитесь по телефону.'}`;
+        } finally {
+          submitBtn.disabled = false;
+        }
+      });
+    }
+  </script>
+
   <div class="tm-section-divider" aria-hidden="true"></div>
 
   <section class="tm-section" id="contacts">

--- a/evacuator.html
+++ b/evacuator.html
@@ -958,12 +958,57 @@
   <script>
     const towForm = document.getElementById('tow-form');
     if (towForm) {
-      towForm.addEventListener('submit', (e) => {
+      const alertBox = towForm.querySelector('.tm-tow__alert');
+      const submitBtn = towForm.querySelector('button[type="submit"]');
+
+      towForm.addEventListener('submit', async (e) => {
         e.preventDefault();
-        const alertBox = towForm.querySelector('.tm-tow__alert');
-        alertBox.textContent = 'Спасибо! Оператор свяжется с вами для уточнения деталей эвакуации.';
+
+        if (!towForm.reportValidity()) return;
+
+        alertBox.textContent = 'Отправляем заявку…';
         alertBox.hidden = false;
-        towForm.reset();
+        submitBtn.disabled = true;
+
+        const formData = new FormData(towForm);
+        const name = (formData.get('name') || '').toString().trim();
+        const phone = (formData.get('phone') || '').toString().trim();
+        const location = (formData.get('location') || '').toString().trim();
+        const coords = (formData.get('coords') || '').toString().trim();
+        const comment = (formData.get('comment') || '').toString().trim();
+
+        const message = [
+          '🚛 Новая заявка на эвакуатор',
+          name ? `Имя: ${name}` : 'Имя не указано',
+          `Телефон: ${phone || '—'}`,
+          location ? `Адрес/локация: ${location}` : 'Адрес не указан',
+          coords ? `Координаты: ${coords}` : '',
+          comment ? `Комментарий: ${comment}` : 'Комментарий: —',
+        ]
+          .filter(Boolean)
+          .join('\n');
+
+        try {
+          const response = await fetch('/api/sendToTelegram', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name, phone, location, coords, message }),
+          });
+
+          const data = await response.json().catch(() => ({}));
+          if (!response.ok || data.ok === false) {
+            const text = data?.error || data?.description || (!response.ok ? await response.text() : '');
+            throw new Error(text || 'Не удалось отправить заявку. Попробуйте ещё раз.');
+          }
+
+          alertBox.textContent = 'Спасибо! Оператор свяжется с вами для уточнения деталей эвакуации.';
+          towForm.reset();
+        } catch (error) {
+          console.error(error);
+          alertBox.textContent = `Ошибка отправки: ${error?.message || 'Попробуйте ещё раз или позвоните нам.'}`;
+        } finally {
+          submitBtn.disabled = false;
+        }
       });
     }
   </script>

--- a/index.html
+++ b/index.html
@@ -1371,7 +1371,7 @@
         status.hidden=false;
 
         try{
-          const response=await fetch('https://tiremasters-3.vercel.app/api/sendToTelegram',{
+          const response=await fetch('/api/sendToTelegram',{
             method:'POST',
             headers:{'Content-Type':'application/json'},
             body:JSON.stringify({name:'',phone,message}),


### PR DESCRIPTION
## Summary
- route all site forms through the Telegram sendToTelegram endpoint
- add client-side submission handlers for evacuator and autoelectric requests with clear status messages
- send structured payloads including contacts and descriptions to @TireMasters_bot

## Testing
- not run (static changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935ad875d78832fa83b26f052cef82f)