### PR TITLE
Send service forms to Telegram via shared module

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -958,7 +958,7 @@
       <h2>Заявка на выезд автоэлектрика</h2>
       <p>Оставьте контакты и опишите симптом — перезвоним за пару минут, подтвердим стоимость и время приезда.</p>
     </div>
-    <form class="tm-form">
+    <form id="avtoelektrik-form" class="tm-form">
       <div class="tm-form-grid">
         <label>Имя
           <input type="text" name="name" placeholder="Как к вам обращаться" required />
@@ -967,77 +967,16 @@
           <input type="tel" name="phone" placeholder="+7 (___) ___-__-__" required />
         </label>
         <label>Адрес или ориентир
-          <input type="text" name="location" placeholder="СПб, район или трасса" />
+          <input type="text" name="address" placeholder="СПб, район или трасса" />
         </label>
       </div>
       <label>Что произошло?
         <textarea name="issue" placeholder="Например: не заводится, горит чек, села батарея"></textarea>
       </label>
       <button type="submit">Вызвать автоэлектрика</button>
+      <div class="tm-form__status form-status" id="avtoelektrik-form-status" role="status"></div>
     </form>
   </section>
-
-  <script>
-    const autoElectricForm = document.querySelector('.tm-form');
-
-    if (autoElectricForm) {
-      const status = document.createElement('p');
-      status.className = 'tm-form__status';
-      status.style.margin = '0';
-      status.style.color = '#B6BBC3';
-      status.setAttribute('role', 'status');
-      status.hidden = true;
-      autoElectricForm.appendChild(status);
-
-      const submitBtn = autoElectricForm.querySelector('button[type="submit"]');
-
-      autoElectricForm.addEventListener('submit', async (event) => {
-        event.preventDefault();
-
-        if (!autoElectricForm.reportValidity()) return;
-
-        status.textContent = 'Отправляем заявку…';
-        status.hidden = false;
-        submitBtn.disabled = true;
-
-        const formData = new FormData(autoElectricForm);
-        const name = (formData.get('name') || '').toString().trim();
-        const phone = (formData.get('phone') || '').toString().trim();
-        const location = (formData.get('location') || '').toString().trim();
-        const issue = (formData.get('issue') || '').toString().trim();
-
-        const message = [
-          '🔌 Заявка на выезд автоэлектрика',
-          name ? `Имя: ${name}` : 'Имя не указано',
-          `Телефон: ${phone || '—'}`,
-          location ? `Адрес/ориентир: ${location}` : 'Адрес не указан',
-          issue ? `Описание: ${issue}` : 'Описание: —',
-        ].join('\n');
-
-        try {
-          const response = await fetch('/api/sendToTelegram', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name, phone, location, message }),
-          });
-
-          const data = await response.json().catch(() => ({}));
-          if (!response.ok || data.ok === false) {
-            const text = data?.error || data?.description || (!response.ok ? await response.text() : '');
-            throw new Error(text || 'Не удалось отправить заявку. Попробуйте ещё раз.');
-          }
-
-          status.textContent = 'Спасибо! Мы свяжемся с вами для уточнения деталей.';
-          autoElectricForm.reset();
-        } catch (error) {
-          console.error(error);
-          status.textContent = `Ошибка отправки: ${error?.message || 'Попробуйте ещё раз или свяжитесь по телефону.'}`;
-        } finally {
-          submitBtn.disabled = false;
-        }
-      });
-    }
-  </script>
 
   <div class="tm-section-divider" aria-hidden="true"></div>
 
@@ -1093,6 +1032,7 @@
     </div>
   </footer>
 
+  <script type="module" src="js/forms.js"></script>
   <script>
     const burger = document.querySelector('.burger button');
     const drawer = document.getElementById('mobileDrawer');

--- a/evacuator.html
+++ b/evacuator.html
@@ -848,15 +848,14 @@
       </div>
     </div>
 
-    <form id="tow-form" class="tm-tow__form" novalidate>
+    <form id="evacuator-form" class="tm-tow__form" novalidate>
       <h3>Заявка на эвакуатор</h3>
       <label>Имя <input type="text" name="name" required></label>
       <label>Телефон <input type="tel" name="phone" placeholder="+7 (___) ___-__-__" required></label>
-      <label>Адрес / Локация <input type="text" name="location" placeholder="Например: Колпино, Пушкин, Шушары, КАД, М11…"></label>
-      <input type="hidden" name="coords" value="">
+      <label>Адрес / Локация <input type="text" name="address" placeholder="Например: Колпино, Пушкин, Шушары, КАД, М11…"></label>
       <label>Комментарий <textarea name="comment" rows="3" placeholder="Что случилось, марка авто, тип проблемы..."></textarea></label>
       <button type="submit" class="btn btn-primary-outline">Отправить заявку</button>
-      <div class="tm-tow__alert" hidden></div>
+      <div class="tm-tow__alert form-status" id="evacuator-form-status" role="status"></div>
     </form>
 
     <div class="tm-tow__gallery" aria-label="Фотографии эвакуатора">
@@ -955,63 +954,6 @@
   }
   </style>
 
-  <script>
-    const towForm = document.getElementById('tow-form');
-    if (towForm) {
-      const alertBox = towForm.querySelector('.tm-tow__alert');
-      const submitBtn = towForm.querySelector('button[type="submit"]');
-
-      towForm.addEventListener('submit', async (e) => {
-        e.preventDefault();
-
-        if (!towForm.reportValidity()) return;
-
-        alertBox.textContent = 'Отправляем заявку…';
-        alertBox.hidden = false;
-        submitBtn.disabled = true;
-
-        const formData = new FormData(towForm);
-        const name = (formData.get('name') || '').toString().trim();
-        const phone = (formData.get('phone') || '').toString().trim();
-        const location = (formData.get('location') || '').toString().trim();
-        const coords = (formData.get('coords') || '').toString().trim();
-        const comment = (formData.get('comment') || '').toString().trim();
-
-        const message = [
-          '🚛 Новая заявка на эвакуатор',
-          name ? `Имя: ${name}` : 'Имя не указано',
-          `Телефон: ${phone || '—'}`,
-          location ? `Адрес/локация: ${location}` : 'Адрес не указан',
-          coords ? `Координаты: ${coords}` : '',
-          comment ? `Комментарий: ${comment}` : 'Комментарий: —',
-        ]
-          .filter(Boolean)
-          .join('\n');
-
-        try {
-          const response = await fetch('/api/sendToTelegram', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ name, phone, location, coords, message }),
-          });
-
-          const data = await response.json().catch(() => ({}));
-          if (!response.ok || data.ok === false) {
-            const text = data?.error || data?.description || (!response.ok ? await response.text() : '');
-            throw new Error(text || 'Не удалось отправить заявку. Попробуйте ещё раз.');
-          }
-
-          alertBox.textContent = 'Спасибо! Оператор свяжется с вами для уточнения деталей эвакуации.';
-          towForm.reset();
-        } catch (error) {
-          console.error(error);
-          alertBox.textContent = `Ошибка отправки: ${error?.message || 'Попробуйте ещё раз или позвоните нам.'}`;
-        } finally {
-          submitBtn.disabled = false;
-        }
-      });
-    }
-  </script>
 </section>
 
 <section id="tm-evacuator-prices" class="tm-section">
@@ -1281,6 +1223,7 @@
   }
 </style>
 
+<script type="module" src="js/forms.js"></script>
 <script>
   document.querySelectorAll('.tm-faq__question').forEach((btn) => {
     btn.addEventListener('click', () => {

--- a/js/forms.js
+++ b/js/forms.js
@@ -1,0 +1,142 @@
+import { sendTelegramLead, TIREMASTERS_CHAT_ID } from './telegram.js';
+
+function formatLeadMessage({
+  serviceTitle,
+  page,
+  name,
+  phone,
+  addressLabel,
+  address,
+  commentLabel,
+  comment,
+}) {
+  const now = new Date().toLocaleString('ru-RU');
+
+  return [
+    `Новая заявка: ${serviceTitle}`,
+    '',
+    `Страница: ${page}`,
+    `Имя: ${name || '—'}`,
+    `Телефон: ${phone}`,
+    `${addressLabel}: ${address || '—'}`,
+    `${commentLabel}: ${comment || '—'}`,
+    '',
+    'Источник: сайт TireMasters',
+    `Время: ${now}`,
+  ].join('\n');
+}
+
+function setupEvacuatorForm() {
+  const form = document.getElementById('evacuator-form');
+  if (!form) return;
+
+  const statusEl = document.getElementById('evacuator-form-status');
+  const submitBtn = form.querySelector('button[type="submit"]');
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    if (!submitBtn || !statusEl) return;
+
+    statusEl.textContent = '';
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Отправляем...';
+
+    const formData = new FormData(form);
+    const name = formData.get('name')?.toString().trim() || '';
+    const phone = formData.get('phone')?.toString().trim() || '';
+    const address = formData.get('address')?.toString().trim() || '';
+    const comment = formData.get('comment')?.toString().trim() || '';
+
+    if (!phone) {
+      statusEl.textContent = 'Укажите, пожалуйста, телефон.';
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Отправить заявку';
+      return;
+    }
+
+    const message = formatLeadMessage({
+      serviceTitle: 'ЭВАКУАТОР',
+      page: 'evacuator.html',
+      name,
+      phone,
+      addressLabel: 'Адрес / локация',
+      address,
+      commentLabel: 'Комментарий',
+      comment,
+    });
+
+    try {
+      await sendTelegramLead(TIREMASTERS_CHAT_ID, message);
+      statusEl.textContent = 'Заявка отправлена. Мы перезвоним в ближайшее время.';
+      form.reset();
+    } catch (error) {
+      console.error(error);
+      statusEl.textContent = 'Не удалось отправить заявку. Попробуйте ещё раз или позвоните по телефону.';
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Отправить заявку';
+    }
+  });
+}
+
+function setupAvtoelektrikForm() {
+  const form = document.getElementById('avtoelektrik-form');
+  if (!form) return;
+
+  const statusEl = document.getElementById('avtoelektrik-form-status');
+  const submitBtn = form.querySelector('button[type="submit"]');
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    if (!submitBtn || !statusEl) return;
+
+    statusEl.textContent = '';
+    submitBtn.disabled = true;
+    submitBtn.textContent = 'Отправляем...';
+
+    const formData = new FormData(form);
+    const name = formData.get('name')?.toString().trim() || '';
+    const phone = formData.get('phone')?.toString().trim() || '';
+    const address = formData.get('address')?.toString().trim() || '';
+    const issue = formData.get('issue')?.toString().trim() || '';
+
+    if (!phone) {
+      statusEl.textContent = 'Укажите, пожалуйста, телефон.';
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Вызвать автоэлектрика';
+      return;
+    }
+
+    const message = formatLeadMessage({
+      serviceTitle: 'АВТОЭЛЕКТРИК',
+      page: 'avtoelektrik.html',
+      name,
+      phone,
+      addressLabel: 'Адрес или ориентир',
+      address,
+      commentLabel: 'Что произошло',
+      comment: issue,
+    });
+
+    try {
+      await sendTelegramLead(TIREMASTERS_CHAT_ID, message);
+      statusEl.textContent = 'Заявка отправлена. Мы перезвоним в ближайшее время.';
+      form.reset();
+    } catch (error) {
+      console.error(error);
+      statusEl.textContent = 'Не удалось отправить заявку. Попробуйте ещё раз или позвоните по телефону.';
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.textContent = 'Вызвать автоэлектрика';
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupEvacuatorForm();
+  setupAvtoelektrikForm();
+});
+
+export { setupEvacuatorForm, setupAvtoelektrikForm };

--- a/js/telegram.js
+++ b/js/telegram.js
@@ -1,0 +1,26 @@
+const TELEGRAM_BOT_TOKEN = '8130437470:AAFRvjDjsNPS2qNXHsBllcVQ4tbW54O7yK8';
+// TODO: подставьте реальный chat_id вашего диалога с ботом
+export const TIREMASTERS_CHAT_ID = '<chat_id_placeholder>';
+
+export async function sendTelegramLead(chatId, message) {
+  const url = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      chat_id: chatId,
+      text: message,
+      parse_mode: 'HTML',
+    }),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => '');
+    throw new Error(`Telegram API error: ${response.status} ${errorText}`);
+  }
+
+  return response.json().catch(() => null);
+}


### PR DESCRIPTION
## Summary
- add reusable Telegram sender with placeholder chat id
- wire evacuator and auto electrician forms to new Telegram flow with localized status messages
- align form fields and UI status blocks for consistent submissions

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935b0a66400832fb6e4247b96826dd6)