### PR TITLE
Send lead notifications to two Telegram chats

### DIFF
--- a/js/telegram.js
+++ b/js/telegram.js
@@ -1,11 +1,12 @@
 const TM_TELEGRAM_BOT_TOKEN = '8130437470:AAFRvjDjsNPS2qNXHsBllcVQ4tbW54O7yK8';
-const TM_TELEGRAM_CHAT_ID = 6010246421;
+const TM_TELEGRAM_CHAT_IDS = [6010246421, 5911021141];
 
 async function sendTelegramLead({ service, name, phone, address, comment }) {
   if (!TM_TELEGRAM_BOT_TOKEN) {
     throw new Error('TELEGRAM_BOT_TOKEN is not configured');
   }
-  if (!TM_TELEGRAM_CHAT_ID) {
+  const chatIds = Array.from(new Set(TM_TELEGRAM_CHAT_IDS.filter(Boolean)));
+  if (!chatIds.length) {
     throw new Error('TELEGRAM_CHAT_ID is not configured');
   }
 
@@ -20,30 +21,34 @@ async function sendTelegramLead({ service, name, phone, address, comment }) {
   const text = textLines.join('\n');
 
   const url = `https://api.telegram.org/bot${TM_TELEGRAM_BOT_TOKEN}/sendMessage`;
-  const payload = {
-    chat_id: TM_TELEGRAM_CHAT_ID,
-    text,
-    parse_mode: 'HTML',
-  };
-
   try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
+    const results = await Promise.all(
+      chatIds.map(async (chatId) => {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            chat_id: chatId,
+            text,
+            parse_mode: 'HTML',
+          }),
+        });
 
-    const data = await response.json();
+        const data = await response.json();
 
-    if (!response.ok || !data.ok) {
-      console.error('Telegram API error', {
-        httpStatus: response.status,
-        telegramResponse: data,
-      });
-      throw new Error(data.description || 'Telegram API error');
-    }
+        if (!response.ok || !data.ok) {
+          console.error('Telegram API error', {
+            httpStatus: response.status,
+            telegramResponse: data,
+          });
+          throw new Error(data.description || 'Telegram API error');
+        }
 
-    console.log('Telegram lead sent successfully', data);
+        return data;
+      })
+    );
+
+    console.log('Telegram lead sent successfully', results);
     return true;
   } catch (error) {
     console.error('Telegram send error', error);


### PR DESCRIPTION
## Summary
- send each website lead to both configured Telegram chat IDs
- de-duplicate chat IDs while keeping the existing message format and parse mode

## Testing
- not run (not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939424c03f4832f968faace5f0ef5a5)