### PR TITLE
Add Yandex.Metrika counter to avtoelektrik page

### DIFF
--- a/avtoelektrik.html
+++ b/avtoelektrik.html
@@ -38,6 +38,19 @@
   <meta name="geo.position" content="59.93863;30.31413" />
   <meta name="ICBM" content="59.93863, 30.31413" />
   <meta name="theme-color" content="#0B0D10" />
+  <!-- Yandex.Metrika counter -->
+  <script type="text/javascript">
+    (function(m,e,t,r,i,k,a){
+        m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+        m[i].l=1*new Date();
+        for (var j = 0; j < document.scripts.length; j++) {if (document.scripts[j].src === r) { return; }}
+        k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)
+    })(window, document,'script','https://mc.yandex.ru/metrika/tag.js?id=105562834', 'ym');
+
+    ym(105562834, 'init', {ssr:true, webvisor:true, clickmap:true, ecommerce:"dataLayer", accurateTrackBounce:true, trackLinks:true});
+  </script>
+  <noscript><div><img src="https://mc.yandex.ru/watch/105562834" style="position:absolute; left:-9999px;" alt="" /></div></noscript>
+  <!-- /Yandex.Metrika counter -->
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600;700&display=swap" rel="stylesheet" />


### PR DESCRIPTION
### Motivation
- Enable analytics tracking on the auto electrician page so it is measured consistently with other site pages.
- Capture user interactions and basic ecommerce signals via Yandex.Metrika for this specific route.

### Description
- Inserted the Yandex.Metrika snippet into the `<head>` of `avtoelektrik.html` with an async loader and `<noscript>` fallback.
- Initialized the counter with ID `105562834` and options `ssr:true, webvisor:true, clickmap:true, ecommerce:"dataLayer", accurateTrackBounce:true, trackLinks:true`.
- Only `avtoelektrik.html` was modified; no layout or styling changes were introduced.

### Testing
- No automated tests were run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964e6510f20832f839e307caa76738a)