### PR TITLE
Add Docker Compose backend, Dockerfile and health endpoint; pin npm registry

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__/
+.venv/
+.env
+.pytest_cache/
+.mypy_cache/
+*.pyc

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,1 @@
+# Example environment variables for the backend

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.115.0
+uvicorn==0.30.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  backend:
+    build:
+      context: ./backend
+    ports:
+      - "8000:8000"
+    env_file:
+      - ./backend/.env
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000
+    restart: unless-stopped

--- a/docs/RUN_LOCAL.md
+++ b/docs/RUN_LOCAL.md
@@ -1,0 +1,37 @@
+# Local Development
+
+## Backend
+
+1. Create the backend environment file from the example:
+
+   ```bash
+   cp backend/.env.example backend/.env
+   ```
+
+2. Start the backend with Docker Compose:
+
+   ```bash
+   docker compose up --build
+   ```
+
+3. Verify the health endpoint:
+
+   ```bash
+   curl http://localhost:8000/health
+   ```
+
+## Frontend
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the dev server:
+
+   ```bash
+   npm run dev
+   ```
+
+Note: `.npmrc` pins the public npm registry to avoid 403 errors during installs.

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+always-auth=false


### PR DESCRIPTION
### Motivation
- Provide a reproducible local way to run the backend via Docker Compose and expose a simple health check at `http://localhost:8000/health`.
- Prevent `npm install` 403 errors by explicitly pinning the public npm registry for the frontend with `frontend/.npmrc`.
- Avoid committing secrets by using `backend/.env.example` and referencing `backend/.env` from `docker-compose.yml`.

### Description
- Add `docker-compose.yml` which defines a `backend` service that builds from `./backend`, maps port `8000:8000`, uses `env_file: ./backend/.env`, runs `uvicorn app.main:app --host 0.0.0.0 --port 8000`, and sets `restart: unless-stopped`.
- Add `backend/Dockerfile` based on `python:3.11-slim` that installs `requirements.txt`, copies the app, exposes port `8000`, and sets the `CMD` to run `uvicorn`.
- Add a minimal FastAPI app at `backend/app/main.py` implementing `GET /health` returning `{"status":"ok"`, plus `backend/requirements.txt`, `backend/.dockerignore`, and `backend/.env.example`.
- Add `frontend/.npmrc` with `registry=https://registry.npmjs.org/` and `always-auth=false`, and add `docs/RUN_LOCAL.md` with instructions to create `backend/.env`, run `docker compose up --build`, and verify the `/health` endpoint.

### Testing
- No automated tests were executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739d838cc8832fa03468a28fad405a)